### PR TITLE
Fix wording for block hashes of negative-height blocks.

### DIFF
--- a/specs/main.md
+++ b/specs/main.md
@@ -66,7 +66,7 @@ Before execution begins, the following is pushed on the stack sequentially:
 1. Block producer address (`byte[32]`, word-aligned).
 1. Transaction gas limit (`uint64`, word-aligned).
 1. Transaction hash (`byte[32]`, word-aligned).
-1. Block hash for the previous 256 blocks, starting from the previous block (`byte[32][256]`, word-aligned). Block hash is `0x00**32` if block height is <= 256.
+1. Block hash for the previous 256 blocks, starting from the previous block (`byte[32][256]`, word-aligned). Block hash is zero (`0x00**32`) for negative block heights.
 1. The [transaction, serialized](./tx_format.md).
 
 `$pc` is initialized to the start of the transaction's script bytecode and execution begins.


### PR DESCRIPTION
Previous wording was unclear.