### PR TITLE
Add script and predicate data fields.

### DIFF
--- a/specs/tx_format.md
+++ b/specs/tx_format.md
@@ -11,20 +11,22 @@
 
 ## Transaction
 
-| name             | type                    | description                              |
-| ---------------- | ----------------------- | ---------------------------------------- |
-| `version`        | `uint32`                | Transaction version. Always `0`.         |
-| `gasPrice`       | `uint64`                | Gas price for transaction.               |
-| `gasLimit`       | `uint64`                | Gas limit for transaction.               |
-| `maturity`       | `uint64`                | Block until which tx cannot be included. |
-| `scriptLength`   | `uint16`                | Script length, in instructions.          |
-| `inputsCount`    | `uint8`                 | Number of inputs.                        |
-| `outputsCount`   | `uint8`                 | Number of outputs.                       |
-| `witnessesCount` | `uint8`                 | Number of witnesses.                     |
-| `script`         | `byte[]`                | Script to execute.                       |
-| `inputs`         | [Input](#input)`[]`     | List of inputs.                          |
-| `outputs`        | [Output](#output)`[]`   | List of outputs.                         |
-| `witnesses`      | [Witness](#witness)`[]` | List of witnesses.                       |
+| name               | type                    | description                              |
+| ------------------ | ----------------------- | ---------------------------------------- |
+| `version`          | `uint32`                | Transaction version. Always `0`.         |
+| `gasPrice`         | `uint64`                | Gas price for transaction.               |
+| `gasLimit`         | `uint64`                | Gas limit for transaction.               |
+| `maturity`         | `uint64`                | Block until which tx cannot be included. |
+| `scriptLength`     | `uint16`                | Script length, in instructions.          |
+| `scriptDataLength` | `uint16`                | Length of script input data, in bytes.   |
+| `inputsCount`      | `uint8`                 | Number of inputs.                        |
+| `outputsCount`     | `uint8`                 | Number of outputs.                       |
+| `witnessesCount`   | `uint8`                 | Number of witnesses.                     |
+| `script`           | `byte[]`                | Script to execute.                       |
+| `scriptData`       | `byte[]`                | Script input data (parameters).          |
+| `inputs`           | [Input](#input)`[]`     | List of inputs.                          |
+| `outputs`          | [Output](#output)`[]`   | List of outputs.                         |
+| `witnesses`        | [Witness](#witness)`[]` | List of witnesses.                       |
 
 Transaction is invalid if `blockheight() < maturity`.
 
@@ -49,13 +51,15 @@ enum  InputType : uint8 {
 
 ### InputCoin
 
-| name           | type       | description                                                            |
-| -------------- | ---------- | ---------------------------------------------------------------------- |
-| `utxoID`       | `byte[32]` | UTXO ID.                                                               |
-| `witnessIndex` | `uint8`    | Index of witness that authorizes spending the coin.                    |
-| `maturity`     | `uint64`   | UTXO being spent must have been created at least this many blocks ago. |
-| `dataLength`   | `uint16`   | Length of data, in bytes.                                              |
-| `data`         | `byte[]`   | Data to input into script.                                             |
+| name                  | type       | description                                                            |
+| --------------------- | ---------- | ---------------------------------------------------------------------- |
+| `utxoID`              | `byte[32]` | UTXO ID.                                                               |
+| `witnessIndex`        | `uint8`    | Index of witness that authorizes spending the coin.                    |
+| `maturity`            | `uint64`   | UTXO being spent must have been created at least this many blocks ago. |
+| `predicateLength`     | `uint16`   | Length of predicate, in instructions.                                  |
+| `predicateDataLength` | `uint16`   | Length of predicate input data, in bytes.                              |
+| `predicate`           | `byte[]`   | Predicate bytecode.                                                    |
+| `predicateData`       | `byte[]`   | Predicate input data (parameters).                                     |
 
 If `h` is the block height the UTXO being spent was created, transaction is invalid if `blockheight() < h + maturity`.
 


### PR DESCRIPTION
Add fields in the transaction for input data (i.e. parameters) to the script and predicate, and clean up naming.