### PR TITLE
Fix predicate jump constraints

### DIFF
--- a/specs/main.md
+++ b/specs/main.md
@@ -75,7 +75,7 @@ For each such input in the transaction, the VM is [initialized](#vm-initializati
 
 In addition, during predicate mode if `$pc` is set to a value greater than the end of predicate bytecode (this would allow bytecode outside the actual predicate), predicate verification halts returning Boolean `false`.
 
-A predicate that halts without returning Boolean `true` does not pass verification, making the entire transaction invalid. Note that predicate validity is monotonic (i.e. if a predicate evaluates to `true` then it will always evaluate to `true` in the future).
+A predicate that halts without returning Boolean `true` does not pass verification, making the entire transaction invalid. Note that predicate validity is monotonic with respect to time (i.e. if a predicate evaluates to `true` then it will always evaluate to `true` in the future).
 
 ## Script Execution
 


### PR DESCRIPTION
Any jump can be used, but it must strictly increase `$pc`.