### PR TITLE
Bound the cost of all operations that operate on variable memory

### DIFF
--- a/specs/main.md
+++ b/specs/main.md
@@ -16,9 +16,11 @@ This document provides the specification for the Fuel Virtual Machine (FuelVM). 
 
 ## Parameters
 
-| name         | type     | value   | note   |
-| ------------ | -------- | ------- | ------ |
-| `VM_MAX_RAM` | `uint64` | `2**20` | 1 MiB. |
+| name                  | type     | value   | note                                  |
+| --------------------- | -------- | ------- | ------------------------------------- |
+| `CONTRACT_MAX_SIZE`   | `uint64` |         | Maximum contract size, in bytes.      |
+| `MEM_MAX_ACCESS_SIZE` | `uint64` |         | Maximum memory access size, in bytes. |
+| `VM_MAX_RAM`          | `uint64` | `2**20` | 1 MiB.                                |
 
 ## Semantics
 

--- a/specs/opcodes.md
+++ b/specs/opcodes.md
@@ -468,6 +468,8 @@ All these opcodes advance the program counter `$pc` by `4` after performing thei
 | Encoding    | `0x00 rd rs rt ru`                          |
 | Notes       |                                             |
 
+If `$ru > MEM_MAX_ACCESS_SIZE`, revert instead.
+
 ### MEMCP: Memory copy
 
 |             |                                      |
@@ -477,6 +479,8 @@ All these opcodes advance the program counter `$pc` by `4` after performing thei
 | Syntax      | `memcp $rd, $rs, $rt`                |
 | Encoding    | `0x00 rd rs rt -`                    |
 | Notes       |                                      |
+
+If `$rt > MEM_MAX_ACCESS_SIZE`, revert instead.
 
 ### SB: Store byte
 
@@ -571,6 +575,8 @@ If the above checks pass, a [call frame](./main.md#call-frames) is pushed at `$s
 | Encoding    | `0x00 rd rs rt ru`                                                                                                                               |
 | Notes       | If `$ru` is greater than the code size, zero bytes are filled in.                                                                                |
 
+If `$ru > MEM_MAX_ACCESS_SIZE`, revert instead.
+
 ### CODEROOT: Code Merkle root
 
 |             |                                                                                                                                       |
@@ -610,6 +616,8 @@ If the above checks pass, a [call frame](./main.md#call-frames) is pushed at `$s
 | Syntax      | `create $rs, $rt`                                                     |
 | Encoding    | `0x00 rs rt - -`                                                      |
 | Notes       |                                                                       |
+
+If `$rt > CONTRACT_MAX_SIZE`, revert instead.
 
 ### LOG: Log event
 
@@ -713,6 +721,8 @@ To get the address, hash the public key with [SHA-2-256](#sha256-sha-2-256).
 | Encoding    | `0x00 rd rs rt -`                                     |
 | Notes       |                                                       |
 
+If `$rt > MEM_MAX_ACCESS_SIZE`, revert instead.
+
 ### SHA256: SHA-2-256
 
 |             |                                                      |
@@ -722,3 +732,5 @@ To get the address, hash the public key with [SHA-2-256](#sha256-sha-2-256).
 | Syntax      | `sha256 $rd, $rs, $rt`                               |
 | Encoding    | `0x00 rd rs rt -`                                    |
 | Notes       |                                                      |
+
+If `$rt > MEM_MAX_ACCESS_SIZE`, revert instead.


### PR DESCRIPTION
Fixes #21.

Limit how much memory can be read from/written to to some parameters (which can be decided later based on empirical constraints).