### PR TITLE
Guarantee transaction length is invariant

### DIFF
--- a/specs/tx_format.md
+++ b/specs/tx_format.md
@@ -84,6 +84,8 @@ If `h` is the block height the UTXO being spent was created, transaction is inva
 | `utxoID`     | `byte[32]` | UTXO ID.     |
 | `contractID` | `byte[32]` | Contract ID. |
 
+Note: when signing a transaction, `utxoID` is set to zero.
+
 ## Output
 
 ```
@@ -112,6 +114,10 @@ enum  OutputType : uint8 {
 | `inputIndex` | `uint8`    | Index of input contract.                                       |
 | `amount`     | `uint64`   | Amount of coins owned by contract after transaction execution. |
 | `stateRoot`  | `byte[32]` | State root of contract after transaction execution.            |
+
+Note: when signing a transaction, `amount` and `stateRoot` are set to zero.
+
+Note: when executing a transaction, `amount` and `stateRoot` are set to zero.
 
 ## Witness
 


### PR DESCRIPTION
Fixes #55.

Previously, block proposers would _add_ extra witness data to transactions to fill in things that were not known at transaction signing time (e.g. the amount of coins owned by a contract post execution of the transaction). This would make the transaction length vary, which would mean that the results of tx execution before and after being included in a block would be different.

We change the rules to instead have zeroes that the block proposer can _replace_ after executing the transaction.