### PR TITLE
Add variable output types

### DIFF
--- a/specs/tx_format.md
+++ b/specs/tx_format.md
@@ -121,7 +121,7 @@ enum  OutputType : uint8 {
 
 Note: when signing a transaction, `amount` and `stateRoot` are set to zero.
 
-Note: when executing a transaction, `amount` and `stateRoot` are set to zero.
+Note: when executing a transaction, `amount` and `stateRoot` are initialized to zero.
 
 ### OutputChange
 
@@ -132,7 +132,7 @@ Note: when executing a transaction, `amount` and `stateRoot` are set to zero.
 
 Note: when signing a transaction, `amount` is set to zero.
 
-Note: when executing a transaction, `amount` is set to zero.
+Note: when executing a transaction, `amount` is initialized to zero.
 
 This output type indicates that the output's amount may vary based on transaction execution, but is otherwise identical to a [Coin](#outputcoin) output. An `amount` of zero after transaction execution indicates that the output is unspendable and can be pruned from the UTXO set.
 
@@ -145,7 +145,7 @@ This output type indicates that the output's amount may vary based on transactio
 
 Note: when signing a transaction, `to` and `amount` are set to zero.
 
-Note: when executing a transaction, `to` and `amount` are set to zero.
+Note: when executing a transaction, `to` and `amount` are initialized to zero.
 
 This output type indicates that the output's amount and owner may vary based on transaction execution, but is otherwise identical to a [Coin](#outputcoin) output. An `amount` of zero after transaction execution indicates that the output is unspendable and can be pruned from the UTXO set.
 


### PR DESCRIPTION
Fixes #35.

Add two output types:
1. Variable based on transaction execution
1. Change to refund unspent gas and free coins to

The plan for variable outputs is to have an opcode to set an output (#22), e.g. `send <output_index> <to> <amount>`. This would revert if the output is already set, or if the amount is 0. Unlike the accounts data model, with UTXOs transfers involve actually creating a new object instead of updating an existing object.