### PR TITLE
Fix description of immediate multiples of 6 bits

### DIFF
--- a/specs/opcodes.md
+++ b/specs/opcodes.md
@@ -68,7 +68,7 @@
 
 ## Reading Guide
 
-This page provides a description of all opcodes for the FuelVM. Encoding should be read as a sequence of one 8-bit value (the opcode identifier) followed by four 6-bit values (the register identifiers or immediate value). A single `i` indicates a 6-bit immediate value, `i i` indicates a 12-bit immediate value and  `i i i` indicates a 24-bit immediate value. All immediate values are interpreted as big-endian unsigned integers.
+This page provides a description of all opcodes for the FuelVM. Encoding should be read as a sequence of one 8-bit value (the opcode identifier) followed by four 6-bit values (the register identifiers or immediate value). A single `i` indicates a 6-bit immediate value, `i i` indicates a 12-bit immediate value, `i i i` indicates an 18-bit immediate value, and `i i i i` indicates a 24-bit immediate value. All immediate values are interpreted as big-endian unsigned integers.
 
 ## Arithmetic/Logic (ALU) Opcodes
 


### PR DESCRIPTION
Was missing description of the 3-6-bit immediate value.