### PR TITLE
Make LOG be a no-op with params

### DIFF
--- a/specs/opcodes.md
+++ b/specs/opcodes.md
@@ -639,15 +639,13 @@ If `$rt > CONTRACT_MAX_SIZE`, revert instead.
 
 ### LOG: Log event
 
-|             |                                                                                                                                                                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Description | Takes `$rs` and `$rt` register values and records a log entry with no topics based on the memory offset of the `$rs` value, with a length given by the `$rt` value. |
-| Operation   | ```$log.push(':' + MEM[$rs, $rt]);```                                                                                                                               |
-| Syntax      | `log $rs, $rt`                                                                                                                                                      |
-| Encoding    | `0x00 rs rt - -`                                                                                                                                                    |
-| Notes       |                                                                                                                                                                     |
-
-<!--TODO-->
+|             |                                |
+| ----------- | ------------------------------ |
+| Description | Log an event. This is a no-op. |
+| Operation   | ```log($rs, $rt, $ru, $rv);``` |
+| Syntax      | `log $rs, $rt, $ru, $rv`       |
+| Encoding    | `0x00 rs rt ru rv`             |
+| Notes       |                                |
 
 ### REVERT: Revert
 


### PR DESCRIPTION
As per #65, make `LOG` opcode a no-op, deferring logic to the client.