### PR TITLE
Math flag fixes and improvements

### DIFF
--- a/specs/main.md
+++ b/specs/main.md
@@ -62,6 +62,7 @@ Persistent state (i.e. storage) is a key-value store with 32-byte keys and 32-by
 | value  | name           | description                                           |
 | ------ | -------------- | ----------------------------------------------------- |
 | `0x01` | `F_UNSAFEMATH` | If bit is set, safe arithmetic and logic is disabled. |
+| `0x02` | `F_WRAPPING`   | If bit is set, wrapping does not cause panic.         |
 
 ## Opcodes
 

--- a/specs/opcodes.md
+++ b/specs/opcodes.md
@@ -83,6 +83,8 @@ All these opcodes advance the program counter `$pc` by `4` after performing thei
 
 If the [`F_UNSAFEMATH`](./main.md#flags) flag is unset, an operation that would have set `$err` to `true` is instead a panic.
 
+If the [`F_WRAPPING`](./main.md#flags) flag is unset, an operation that would have set `$of` to a non-zero value is instead a panic.
+
 ### ADD: Add
 
 |             |                        |


### PR DESCRIPTION
- Add a wrapping flag to panic on wrap, enabled by default.
- Remove automatic remainder setting from division to make things simpler (modulus opcode exists anyways, and it's not often both will be needed).