### PR TITLE
Rename opcode registers to ABCD

### DIFF
--- a/specs/vm/opcodes.md
+++ b/specs/vm/opcodes.md
@@ -74,7 +74,7 @@
 
 ## Reading Guide
 
-This page provides a description of all opcodes for the FuelVM. Encoding should be read as a sequence of one 8-bit value (the opcode identifier) followed by four 6-bit values (the register identifiers or immediate value). A single `i` indicates a 6-bit immediate value, `i i` indicates a 12-bit immediate value, `i i i` indicates an 18-bit immediate value, and `i i i i` indicates a 24-bit immediate value. All immediate values are interpreted as big-endian unsigned integers.
+This page provides a description of all opcodes for the FuelVM. Encoding is read as a sequence of one 8-bit value (the opcode identifier) followed by four 6-bit values (the register identifiers or immediate value). A single `i` indicates a 6-bit immediate value, `i i` indicates a 12-bit immediate value, `i i i` indicates an 18-bit immediate value, and `i i i i` indicates a 24-bit immediate value. All immediate values are interpreted as big-endian unsigned integers.
 
 Some opcodes may _panic_, i.e. enter an unrecoverable state. How a panic is handled depends on [context](./main.md#contexts):
 * In a predicate context, [return](#return-return-from-context) `false`.
@@ -95,13 +95,13 @@ If the [`F_WRAPPING`](./main.md#flags) flag is unset, an operation that would ha
 |             |                        |
 | ----------- | ---------------------- |
 | Description | Adds two registers.    |
-| Operation   | ```$rd = $rs + $rt;``` |
-| Syntax      | `add $rd, $rs, $rt`    |
-| Encoding    | `0x00 rd rs rt -`      |
+| Operation   | ```$rA = $rB + $rC;``` |
+| Syntax      | `add $rA, $rB, $rC`    |
+| Encoding    | `0x00 rA rB rC -`      |
 | Notes       |                        |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the overflow of the operation.
 
@@ -112,13 +112,13 @@ Panic if:
 |             |                                         |
 | ----------- | --------------------------------------- |
 | Description | Adds a register and an immediate value. |
-| Operation   | ```$rt = $rs + imm;```                  |
-| Syntax      | `addi $rd, $rs, immediate`              |
-| Encoding    | `0x00 rs rt i i`                        |
+| Operation   | ```$rA = $rB + imm;```                  |
+| Syntax      | `addi $rA, $rB, immediate`              |
+| Encoding    | `0x00 rA rB i i`                        |
 | Notes       |                                         |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the overflow of the operation.
 
@@ -129,13 +129,13 @@ Panic if:
 |             |                             |
 | ----------- | --------------------------- |
 | Description | Bitwise ANDs two registers. |
-| Operation   | ```$rd = $rs & $rt;```      |
-| Syntax      | `and $rd, $rs, $rt`         |
-| Encoding    | `0x00 rd rs rt -`           |
+| Operation   | ```$rA = $rB & $rC;```      |
+| Syntax      | `and $rA, $rB, $rC`         |
+| Encoding    | `0x00 rA rB rC -`           |
 | Notes       |                             |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -144,13 +144,13 @@ Panic if:
 |             |                                                 |
 | ----------- | ----------------------------------------------- |
 | Description | Bitwise ANDs a register and an immediate value. |
-| Operation   | ```$rd = $rs & imm;```                          |
-| Syntax      | `andi $rd, $rs, imm`                            |
-| Encoding    | `0x00 rd rs i i`                                |
+| Operation   | ```$rA = $rB & imm;```                          |
+| Syntax      | `andi $rA, $rB, imm`                            |
+| Encoding    | `0x00 rA rB i i`                                |
 | Notes       |                                                 |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -159,15 +159,15 @@ Panic if:
 |             |                         |
 | ----------- | ----------------------- |
 | Description | Divides two registers.  |
-| Operation   | ```$rd = $rs // $rt;``` |
-| Syntax      | `div $rd, $rs, $rt`     |
-| Encoding    | `0x00 rd rs rt -`       |
+| Operation   | ```$rA = $rB // $rC;``` |
+| Syntax      | `div $rA, $rB, $rC`     |
+| Encoding    | `0x00 rA rB rC -`       |
 | Notes       |                         |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
-If `$rt == 0`, `$rd` is cleared and `$err` is set to `true`.
+If `$rC == 0`, `$rA` is cleared and `$err` is set to `true`.
 
 Otherwise, `$err` is cleared.
 
@@ -178,15 +178,15 @@ Otherwise, `$err` is cleared.
 |             |                                            |
 | ----------- | ------------------------------------------ |
 | Description | Divides a register and an immediate value. |
-| Operation   | ```$rd = $rs // imm;```                    |
-| Syntax      | `divi $rd, $rs, imm`                       |
-| Encoding    | `0x00 rd rs i i`                           |
+| Operation   | ```$rA = $rB // imm;```                    |
+| Syntax      | `divi $rA, $rB, imm`                       |
+| Encoding    | `0x00 rA rB i i`                           |
 | Notes       |                                            |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
-If `imm == 0`, `$rd` is cleared and `$err` is set to `true`.
+If `imm == 0`, `$rA` is cleared and `$err` is set to `true`.
 
 Otherwise, `$err` is cleared.
 
@@ -197,13 +197,13 @@ Otherwise, `$err` is cleared.
 |             |                                      |
 | ----------- | ------------------------------------ |
 | Description | Compares two registers for equality. |
-| Operation   | ```$rd = $rs == $rt;```              |
-| Syntax      | `eq $rd, $rs, $rt`                   |
-| Encoding    | `0x00 rd rs rt -`                    |
+| Operation   | ```$rA = $rB == $rC;```              |
+| Syntax      | `eq $rA, $rB, $rC`                   |
+| Encoding    | `0x00 rA rB rC -`                    |
 | Notes       |                                      |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -212,13 +212,13 @@ Panic if:
 |             |                                              |
 | ----------- | -------------------------------------------- |
 | Description | Raises one register to the power of another. |
-| Operation   | ```$rd = $rs ** $rt;```                      |
-| Syntax      | `exp $rd, $rs, $rt`                          |
-| Encoding    | `0x00 rd rs rt -`                            |
+| Operation   | ```$rA = $rB ** $rC;```                      |
+| Syntax      | `exp $rA, $rB, $rC`                          |
+| Encoding    | `0x00 rA rB rC -`                            |
 | Notes       |                                              |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 If the result cannot fit in 8 bytes, `$of` is set to `1`, otherwise `$of` is cleared.
 
@@ -229,13 +229,13 @@ If the result cannot fit in 8 bytes, `$of` is set to `1`, otherwise `$of` is cle
 |             |                                                         |
 | ----------- | ------------------------------------------------------- |
 | Description | Raises one register to the power of an immediate value. |
-| Operation   | ```$rd = $rs ** imm;```                                 |
-| Syntax      | `expi $rd, $rs, imm`                                    |
-| Encoding    | `0x00 rd rt i i`                                        |
+| Operation   | ```$rA = $rB ** imm;```                                 |
+| Syntax      | `expi $rA, $rB, imm`                                    |
+| Encoding    | `0x00 rA rB i i`                                        |
 | Notes       |                                                         |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 If the result cannot fit in 8 bytes, `$of` is set to `1`, otherwise `$of` is cleared.
 
@@ -246,13 +246,13 @@ If the result cannot fit in 8 bytes, `$of` is set to `1`, otherwise `$of` is cle
 |             |                                          |
 | ----------- | ---------------------------------------- |
 | Description | Compares two registers for greater-than. |
-| Operation   | ```$rd = $rs > $rt;```                   |
-| Syntax      | `gt $rd, $rs, $rt`                       |
-| Encoding    | `0x00 rd rs rt -`                        |
+| Operation   | ```$rA = $rB > $rC;```                   |
+| Syntax      | `gt $rA, $rB, $rC`                       |
+| Encoding    | `0x00 rA rB rC -`                        |
 | Notes       |                                          |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -260,18 +260,18 @@ Panic if:
 
 |             |                                              |
 | ----------- | -------------------------------------------- |
-| Description | The (integer) logarithm base `$rt` of `$rs`. |
-| Operation   | ```$rd = math.floor(math.log($rs, $rt));```  |
-| Syntax      | `mathlog $rd, $rs, $rt`                      |
-| Encoding    | `0x00 rd rs rt -`                            |
+| Description | The (integer) logarithm base `$rC` of `$rB`. |
+| Operation   | ```$rA = math.floor(math.log($rB, $rC));```  |
+| Syntax      | `mathlog $rA, $rB, $rC`                      |
+| Encoding    | `0x00 rA rB rC -`                            |
 | Notes       |                                              |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
-If `$rs == 0`, both `$rd` and `$of` are cleared and `$err` is set to `true`.
+If `$rB == 0`, both `$rA` and `$of` are cleared and `$err` is set to `true`.
 
-If `$rt <= 1`, both `$rd` and `$of` are cleared and `$err` is set to `true`.
+If `$rC <= 1`, both `$rA` and `$of` are cleared and `$err` is set to `true`.
 
 Otherwise, `$of` and `$err` are cleared.
 
@@ -279,16 +279,16 @@ Otherwise, `$of` and `$err` are cleared.
 
 |             |                                              |
 | ----------- | -------------------------------------------- |
-| Description | The (integer) `$rt`th root of `$rs`.         |
-| Operation   | ```$rd = math.floor(math.root($rs, $rt));``` |
-| Syntax      | `mathroot $rd, $rs, $rt`                     |
-| Encoding    | `0x00 rd rs rt -`                            |
+| Description | The (integer) `$rC`th root of `$rB`.         |
+| Operation   | ```$rA = math.floor(math.root($rB, $rC));``` |
+| Syntax      | `mathroot $rA, $rB, $rC`                     |
+| Encoding    | `0x00 rA rB rC -`                            |
 | Notes       |                                              |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
-If `$rt == 0`, both `$rd` and `$of` are cleared and `$err` is set to `true`.
+If `$rC == 0`, both `$rA` and `$of` are cleared and `$err` is set to `true`.
 
 Otherwise, `$of` and `$err` are cleared.
 
@@ -297,15 +297,15 @@ Otherwise, `$of` and `$err` are cleared.
 |             |                                    |
 | ----------- | ---------------------------------- |
 | Description | Modulo remainder of two registers. |
-| Operation   | ```$rd = $rs % $rt;```             |
-| Syntax      | `mod $rd, $rs, $rt`                |
-| Encoding    | `0x00 rd rs rt -`                  |
+| Operation   | ```$rA = $rB % $rC;```             |
+| Syntax      | `mod $rA, $rB, $rC`                |
+| Encoding    | `0x00 rA rB rC -`                  |
 | Notes       |                                    |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
-If `$rt == 0`, both `$rd` and `$of` are cleared and `$err` is set to `true`.
+If `$rC == 0`, both `$rA` and `$of` are cleared and `$err` is set to `true`.
 
 Otherwise, `$of` and `$err` are cleared.
 
@@ -314,15 +314,15 @@ Otherwise, `$of` and `$err` are cleared.
 |             |                                                        |
 | ----------- | ------------------------------------------------------ |
 | Description | Modulo remainder of a register and an immediate value. |
-| Operation   | ```$rd = $rs % imm;```                                 |
-| Syntax      | `modi $rd, $rs, imm`                                   |
-| Encoding    | `0x00 rd rs i i`                                       |
+| Operation   | ```$rA = $rB % imm;```                                 |
+| Syntax      | `modi $rA, $rB, imm`                                   |
+| Encoding    | `0x00 rA rB i i`                                       |
 | Notes       |                                                        |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
-If `imm == 0`, both `$rd` and `$of` are cleared and `$err` is set to `true`.
+If `imm == 0`, both `$rA` and `$of` are cleared and `$err` is set to `true`.
 
 Otherwise, `$of` and `$err` are cleared.
 
@@ -331,13 +331,13 @@ Otherwise, `$of` and `$err` are cleared.
 |             |                           |
 | ----------- | ------------------------- |
 | Description | Multiplies two registers. |
-| Operation   | ```$rd = $rs * $rt;```    |
-| Syntax      | `mul $rd, $rs, $rt`       |
-| Encoding    | `0x00 rd rs rt -`         |
+| Operation   | ```$rA = $rB * $rC;```    |
+| Syntax      | `mul $rA, $rB, $rC`       |
+| Encoding    | `0x00 rA rB rC -`         |
 | Notes       |                           |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the overflow of the operation.
 
@@ -348,13 +348,13 @@ Panic if:
 |             |                                               |
 | ----------- | --------------------------------------------- |
 | Description | Multiplies a register and an immediate value. |
-| Operation   | ```$rd = $rs * imm;```                        |
-| Syntax      | `mul $rd, $rs, imm`                           |
-| Encoding    | `0x00 rd rs i i`                              |
+| Operation   | ```$rA = $rB * imm;```                        |
+| Syntax      | `mul $rA, $rB, imm`                           |
+| Encoding    | `0x00 rA rB i i`                              |
 | Notes       |                                               |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the overflow of the operation.
 
@@ -377,13 +377,13 @@ Panic if:
 |             |                         |
 | ----------- | ----------------------- |
 | Description | Bitwise NOT a register. |
-| Operation   | ```$rd = ~$rs;```       |
-| Syntax      | `not $rd, $rs`          |
-| Encoding    | `0x00 rd rs - -`        |
+| Operation   | ```$rA = ~$rB;```       |
+| Syntax      | `not $rA, $rB`          |
+| Encoding    | `0x00 rA rB - -`        |
 | Notes       |                         |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -392,13 +392,13 @@ Panic if:
 |             |                            |
 | ----------- | -------------------------- |
 | Description | Bitwise ORs two registers. |
-| Operation   | ```$rd = $rs | $rt;```     |
-| Syntax      | `or $rd, $rs, $rt`         |
-| Encoding    | `0x00 rd rs rt -`          |
+| Operation   | ```$rA = $rB | $rC;```     |
+| Syntax      | `or $rA, $rB, $rC`         |
+| Encoding    | `0x00 rA rB rC -`          |
 | Notes       |                            |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -407,13 +407,13 @@ Panic if:
 |             |                                                |
 | ----------- | ---------------------------------------------- |
 | Description | Bitwise ORs a register and an immediate value. |
-| Operation   | ```$rd = $rs | imm;```                         |
-| Syntax      | `ori $rd, $rs, imm`                            |
-| Encoding    | `0x00 rd rs i i`                               |
+| Operation   | ```$rA = $rB | imm;```                         |
+| Syntax      | `ori $rA, $rB, imm`                            |
+| Encoding    | `0x00 rA rB i i`                               |
 | Notes       |                                                |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -422,13 +422,13 @@ Panic if:
 |             |                                       |
 | ----------- | ------------------------------------- |
 | Description | Left shifts a register by a register. |
-| Operation   | ```$rd = $rs << $rt;```               |
-| Syntax      | `sll $rd, $rs, $rt`                   |
-| Encoding    | `0x00 rd rs rt -`                     |
+| Operation   | ```$rA = $rB << $rC;```               |
+| Syntax      | `sll $rA, $rB, $rC`                   |
+| Encoding    | `0x00 rA rB rC -`                     |
 | Notes       | Zeroes are shifted in.                |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the overflow of the operation.
 
@@ -439,13 +439,13 @@ Panic if:
 |             |                                               |
 | ----------- | --------------------------------------------- |
 | Description | Left shifts a register by an immediate value. |
-| Operation   | ```$rd = $rs << imm;```                       |
-| Syntax      | `slli $rd, $rs, imm`                          |
-| Encoding    | `0x00 rd rs i i`                              |
+| Operation   | ```$rA = $rB << imm;```                       |
+| Syntax      | `slli $rA, $rB, imm`                          |
+| Encoding    | `0x00 rA rB i i`                              |
 | Notes       | Zeroes are shifted in.                        |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the overflow of the operation.
 
@@ -456,13 +456,13 @@ Panic if:
 |             |                                        |
 | ----------- | -------------------------------------- |
 | Description | Right shifts a register by a register. |
-| Operation   | ```$rd = $rs >> $rt;```                |
-| Syntax      | `srl $rd, $rs, $rt`                    |
-| Encoding    | `0x00 rd rs rt -`                      |
+| Operation   | ```$rA = $rB >> $rC;```                |
+| Syntax      | `srl $rA, $rB, $rC`                    |
+| Encoding    | `0x00 rA rB rC -`                      |
 | Notes       | Zeroes are shifted in.                 |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the underflow of the operation, as though `$of` is the high byte of a 128-bit register.
 
@@ -473,13 +473,13 @@ Panic if:
 |             |                                                |
 | ----------- | ---------------------------------------------- |
 | Description | Right shifts a register by an immediate value. |
-| Operation   | ```$rd = $rs >> imm;```                        |
-| Syntax      | `srli $rd, $rs, imm`                           |
-| Encoding    | `0x00 rd rs i i`                               |
+| Operation   | ```$rA = $rB >> imm;```                        |
+| Syntax      | `srli $rA, $rB, imm`                           |
+| Encoding    | `0x00 rA rB i i`                               |
 | Notes       | Zeroes are shifted in.                         |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the underflow of the operation, as though `$of` is the high byte of a 128-bit register.
 
@@ -490,13 +490,13 @@ Panic if:
 |             |                                                  |
 | ----------- | ------------------------------------------------ |
 | Description | Subtracts two registers.                         |
-| Operation   | ```$rd = $rs - $rt;```                           |
-| Syntax      | `sub $rd, $rs, $rt`                              |
-| Encoding    | `0x00 rd rs rt -`                                |
+| Operation   | ```$rA = $rB - $rC;```                           |
+| Syntax      | `sub $rA, $rB, $rC`                              |
+| Encoding    | `0x00 rA rB rC -`                                |
 | Notes       | `$of` is assigned the overflow of the operation. |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the underflow of the operation, as though `$of` is the high byte of a 128-bit register.
 
@@ -507,13 +507,13 @@ Panic if:
 |             |                                                  |
 | ----------- | ------------------------------------------------ |
 | Description | Subtracts a register and an immediate value.     |
-| Operation   | ```$rd = $rs - $rt;```                           |
-| Syntax      | `subi $rd, $rs, $rt`                             |
-| Encoding    | `0x00 rd rs rt -`                                |
+| Operation   | ```$rA = $rB - $rC;```                           |
+| Syntax      | `subi $rA, $rB, $rC`                             |
+| Encoding    | `0x00 rA rB rC -`                                |
 | Notes       | `$of` is assigned the overflow of the operation. |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` is assigned the underflow of the operation, as though `$of` is the high byte of a 128-bit register.
 
@@ -524,13 +524,13 @@ Panic if:
 |             |                             |
 | ----------- | --------------------------- |
 | Description | Bitwise XORs two registers. |
-| Operation   | ```$rd = $rs ^ $rt;```      |
-| Syntax      | `xor $rd, $rs, $rt `        |
-| Encoding    | `0x00 rd rs rt -`           |
+| Operation   | ```$rA = $rB ^ $rC;```      |
+| Syntax      | `xor $rA, $rB, $rC `        |
+| Encoding    | `0x00 rA rB rC -`           |
 | Notes       |                             |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -539,13 +539,13 @@ Panic if:
 |             |                                                 |
 | ----------- | ----------------------------------------------- |
 | Description | Bitwise XORs a register and an immediate value. |
-| Operation   | ```$rd = $rs ^ imm;```                          |
-| Syntax      | `xori $rt, $rs, imm `                           |
-| Encoding    | `0x00 rs rt i i`                                |
+| Operation   | ```$rA = $rB ^ imm;```                          |
+| Syntax      | `xori $rA, $rB, imm `                           |
+| Encoding    | `0x00 rA rB i i`                                |
 | Notes       |                                                 |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 `$of` and `$err` are cleared.
 
@@ -555,17 +555,17 @@ Panic if:
 
 |             |                                                             |
 | ----------- | ----------------------------------------------------------- |
-| Description | Set `$rd` to `true` if the `$rt <= tx.input[$rs].maturity`. |
-| Operation   | ```$rd = checkinputmaturityverify($rs, $rt);```             |
-| Syntax      | `cimv $rd $rs $rt`                                          |
-| Encoding    | `0x00 rd rs rt -`                                           |
+| Description | Set `$rA` to `true` if the `$rC <= tx.input[$rB].maturity`. |
+| Operation   | ```$rA = checkinputmaturityverify($rB, $rC);```             |
+| Syntax      | `cimv $rA $rB $rC`                                          |
+| Encoding    | `0x00 rA rB rC -`                                           |
 | Notes       |                                                             |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
-* `$rt > tx.input[$rs].maturity`
-* the input `$rs` is not of type [`InputType.Coin`](../protocol/tx_format.md)
-* `$rs > tx.inputsCount`
+* `$rA` is a [reserved register](./main.md#semantics)
+* `$rC > tx.input[$rs].maturity`
+* the input `$rB` is not of type [`InputType.Coin`](../protocol/tx_format.md)
+* `$rB > tx.inputsCount`
 
 Otherwise, advance the program counter `$pc` by `4`.
 
@@ -575,15 +575,15 @@ See also: [BIP-112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawi
 
 |             |                                                  |
 | ----------- | ------------------------------------------------ |
-| Description | Set `$rd` to `true` if `$rs <= tx.maturity`.     |
-| Operation   | ```$rd = checktransactionmaturityverify($rs);``` |
-| Syntax      | `ctmv $rd $rs`                                   |
-| Encoding    | `0x00 rd rs - -`                                 |
+| Description | Set `$rA` to `true` if `$rB <= tx.maturity`.     |
+| Operation   | ```$rA = checktransactionmaturityverify($rB);``` |
+| Syntax      | `ctmv $rA $rB`                                   |
+| Encoding    | `0x00 rA rB - -`                                 |
 | Notes       |                                                  |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
-* `$rs > tx.maturity`
+* `$rA` is a [reserved register](./main.md#semantics)
+* `$rB > tx.maturity`
 
 Otherwise, advance the program counter `$pc` by `4`.
 
@@ -606,10 +606,10 @@ Panic if:
 
 |             |                                                                                        |
 | ----------- | -------------------------------------------------------------------------------------- |
-| Description | Jump to the code instruction offset by `imm` if `$rs` is not zero.                     |
-| Operation   | ```if $rs != 0:```<br>```  $pc = $is + imm * 4;```<br>```else:```<br>```  $pc += 4;``` |
-| Syntax      | `jnzi $rs`                                                                             |
-| Encoding    | `0x00 rs i i i`                                                                        |
+| Description | Jump to the code instruction offset by `imm` if `$rA` is not zero.                     |
+| Operation   | ```if $rA != 0:```<br>```  $pc = $is + imm * 4;```<br>```else:```<br>```  $pc += 4;``` |
+| Syntax      | `jnzi $rA`                                                                             |
+| Encoding    | `0x00 rA i i i`                                                                        |
 | Notes       |                                                                                        |
 
 Panic if:
@@ -619,13 +619,13 @@ Panic if:
 
 |             |                                                              |
 | ----------- | ------------------------------------------------------------ |
-| Description | Returns from [context](./main.md#contexts) with value `$rs`. |
-| Operation   | ```return($rs);```                                           |
-| Syntax      | `return $rs`                                                 |
-| Encoding    | `0x00 rs - - -`                                              |
+| Description | Returns from [context](./main.md#contexts) with value `$rA`. |
+| Operation   | ```return($rA);```                                           |
+| Syntax      | `return $rA`                                                 |
+| Encoding    | `0x00 rA - - -`                                              |
 | Notes       |                                                              |
 
-If current context is external, cease VM execution and return `$rs`.
+If current context is external, cease VM execution and return `$rA`.
 
 Returns from contract call, popping the call frame. Before popping:
 1. Return the unused forwarded gas to the caller:
@@ -643,154 +643,154 @@ All these opcodes advance the program counter `$pc` by `4` after performing thei
 |             |                                        |
 | ----------- | -------------------------------------- |
 | Description | Extend the current call frame's stack. |
-| Operation   | ```$sp = $sp + $rs```                  |
-| Syntax      | `cfe $rs`                              |
-| Encoding    | `0x00 rs - - -`                        |
+| Operation   | ```$sp = $sp + $rA```                  |
+| Syntax      | `cfe $rA`                              |
+| Encoding    | `0x00 rA - - -`                        |
 | Notes       | Does not initialize memory.            |
 
 Panic if:
-- `$sp + $rs` overflows
-- `$sp + $rs > $hp`
+- `$sp + $rA` overflows
+- `$sp + $rA > $hp`
 
 ### CFS: Shrink call frame
 
 |             |                                        |
 | ----------- | -------------------------------------- |
 | Description | Shrink the current call frame's stack. |
-| Operation   | ```$sp = $sp - $rs```                  |
-| Syntax      | `cfs $rs`                              |
-| Encoding    | `0x00 rs - - -`                        |
+| Operation   | ```$sp = $sp - $rA```                  |
+| Syntax      | `cfs $rA`                              |
+| Encoding    | `0x00 rA - - -`                        |
 | Notes       | Does not clear memory.                 |
 
 Panic if:
-- `$sp - $rs` underflows
-- `$sp - $rs < $ssp`
+- `$sp - $rA` underflows
+- `$sp - $rA < $ssp`
 
 ### LB: Load byte
 
 |             |                                                              |
 | ----------- | ------------------------------------------------------------ |
 | Description | A byte is loaded from the specified address offset by `imm`. |
-| Operation   | ```$rd = MEM[$rs + imm, 1];```                               |
-| Syntax      | `lb $rd, $rs, imm`                                           |
-| Encoding    | `0x00 rd rs i i`                                             |
+| Operation   | ```$rA = MEM[$rB + imm, 1];```                               |
+| Syntax      | `lb $rA, $rB, imm`                                           |
+| Encoding    | `0x00 rA rB i i`                                             |
 | Notes       |                                                              |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
-- `$rs + imm + 1` overflows
-- `$rs + imm + 1 > VM_MAX_RAM`
+* `$rA` is a [reserved register](./main.md#semantics)
+- `$rB + imm + 1` overflows
+- `$rB + imm + 1 > VM_MAX_RAM`
 
 ### LW: Load word
 
 |             |                                                              |
 | ----------- | ------------------------------------------------------------ |
 | Description | A word is loaded from the specified address offset by `imm`. |
-| Operation   | ```$rd = MEM[$rs + imm, 8];```                               |
-| Syntax      | `lw $rd, $rs, imm`                                           |
-| Encoding    | `0x00 rd rs i i`                                             |
+| Operation   | ```$rA = MEM[$rB + imm, 8];```                               |
+| Syntax      | `lw $rA, $rB, imm`                                           |
+| Encoding    | `0x00 rA rB i i`                                             |
 | Notes       |                                                              |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
-- `$rs + imm + 8` overflows
-- `$rs + imm + 8 > VM_MAX_RAM`
+* `$rA` is a [reserved register](./main.md#semantics)
+- `$rB + imm + 8` overflows
+- `$rB + imm + 8 > VM_MAX_RAM`
 
 ### MALLOC: Allocate memory
 
 |             |                                           |
 | ----------- | ----------------------------------------- |
 | Description | Allocate a number of bytes from the heap. |
-| Operation   | ```$hp = $hp - $rs;```                    |
-| Syntax      | `malloc $rs`                              |
-| Encoding    | `0x00 rs - - -`                           |
+| Operation   | ```$hp = $hp - $rA;```                    |
+| Syntax      | `malloc $rA`                              |
+| Encoding    | `0x00 rA - - -`                           |
 | Notes       | Does not initialize memory.               |
 
 Panic if:
-- `$hp - $rs` underflows
-- `$hp - $rs < $sp`
+- `$hp - $rA` underflows
+- `$hp - $rA < $sp`
 
 ### MEMCLEAR: Memory clear
 
 |             |                          |
 | ----------- | ------------------------ |
 | Description | Clear bytes in memory.   |
-| Operation   | ```MEM[$rd, $rs] = 0;``` |
-| Syntax      | `memclear $rs`           |
-| Encoding    | `0x00 rd rs - -`         |
+| Operation   | ```MEM[$rA, $rB] = 0;``` |
+| Syntax      | `memclear $rA, $rB`      |
+| Encoding    | `0x00 rA rB - -`         |
 | Notes       |                          |
 
 Panic if:
-* `$rd + $rs` overflows
-* `$rd + $rs > VM_MAX_RAM`
-* `$rs > MEM_MAX_ACCESS_SIZE`
-* The memory range `MEM[$rd, $rs]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + $rB` overflows
+* `$rA + $rB > VM_MAX_RAM`
+* `$rB > MEM_MAX_ACCESS_SIZE`
+* The memory range `MEM[$rA, $rB]`  does not pass [ownership check](./main.md#ownership)
 
 ### MEMCP: Memory copy
 
 |             |                                      |
 | ----------- | ------------------------------------ |
 | Description | Copy bytes in memory.                |
-| Operation   | ```MEM[$rd, $rt] = MEM[$rs, $rt];``` |
-| Syntax      | `memcp $rd, $rs, $rt`                |
-| Encoding    | `0x00 rd rs rt -`                    |
+| Operation   | ```MEM[$rA, $rC] = MEM[$rB, $rC];``` |
+| Syntax      | `memcp $rA, $rB, $rC`                |
+| Encoding    | `0x00 rA rB rC -`                    |
 | Notes       |                                      |
 
 Panic if:
-* `$rd + $rt` overflows
-* `$rs + $rt` overflows
-* `$rd + $rt > VM_MAX_RAM`
-* `$rs + $rt > VM_MAX_RAM`
-* `$rt > MEM_MAX_ACCESS_SIZE`
-* The memory range `MEM[$rd, $rt]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + $rC` overflows
+* `$rB + $rC` overflows
+* `$rA + $rC > VM_MAX_RAM`
+* `$rB + $rC > VM_MAX_RAM`
+* `$rC > MEM_MAX_ACCESS_SIZE`
+* The memory range `MEM[$rA, $rC]`  does not pass [ownership check](./main.md#ownership)
 
 ### MEMEQ: Memory equality
 
 |             |                                             |
 | ----------- | ------------------------------------------- |
 | Description | Compare bytes in memory.                    |
-| Operation   | ```$rd = MEM[$rs, $ru] == MEM[$rt, $ru];``` |
-| Syntax      | `memeq $rd, $rs, $rt, $ru`                  |
-| Encoding    | `0x00 rd rs rt ru`                          |
+| Operation   | ```$rA = MEM[$rB, $rD] == MEM[$rC, $rD];``` |
+| Syntax      | `memeq $rA, $rB, $rC, $rD`                  |
+| Encoding    | `0x00 rA rB rC rD`                          |
 | Notes       |                                             |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
-* `$rs + $ru` overflows
-* `$rt + $ru` overflows
-* `$rs + $ru > VM_MAX_RAM`
-* `$rt + $ru > VM_MAX_RAM`
-* `$ru > MEM_MAX_ACCESS_SIZE`
+* `$rA` is a [reserved register](./main.md#semantics)
+* `$rB + $rD` overflows
+* `$rC + $rD` overflows
+* `$rB + $rD > VM_MAX_RAM`
+* `$rC + $rD > VM_MAX_RAM`
+* `$rD > MEM_MAX_ACCESS_SIZE`
 
 ### SB: Store byte
 
 |             |                                                                                     |
 | ----------- | ----------------------------------------------------------------------------------- |
-| Description | The least significant byte of `$rs` is stored at the address `$rd` offset by `imm`. |
-| Operation   | ```MEM[$rd + imm, 1] = $rs[7, 1];```                                                |
-| Syntax      | `sb $rd, $rs, imm`                                                                  |
-| Encoding    | `0x00 rd rs i i`                                                                    |
+| Description | The least significant byte of `$rB` is stored at the address `$rA` offset by `imm`. |
+| Operation   | ```MEM[$rA + imm, 1] = $rB[7, 1];```                                                |
+| Syntax      | `sb $rA, $rB, imm`                                                                  |
+| Encoding    | `0x00 rA rB i i`                                                                    |
 | Notes       |                                                                                     |
 
 Panic if:
-* `$rd + imm + 1` overflows
-* `$rd + imm + 1 > VM_MAX_RAM`
-* The memory range `MEM[$rd + imm, 1]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + imm + 1` overflows
+* `$rA + imm + 1 > VM_MAX_RAM`
+* The memory range `MEM[$rA + imm, 1]`  does not pass [ownership check](./main.md#ownership)
 
 ### SW: Store word
 
 |             |                                                                    |
 | ----------- | ------------------------------------------------------------------ |
-| Description | The value of `$rs` is stored at the address `$rd` offset by `imm`. |
-| Operation   | ```MEM[$rd + imm, 8] = $rs;```                                     |
-| Syntax      | `sw $rd, $rs, imm`                                                 |
-| Encoding    | `0x00 rd rs i i`                                                   |
+| Description | The value of `$rB` is stored at the address `$rA` offset by `imm`. |
+| Operation   | ```MEM[$rA + imm, 8] = $rB;```                                     |
+| Syntax      | `sw $rA, $rB, imm`                                                 |
+| Encoding    | `0x00 rA rB i i`                                                   |
 | Notes       |                                                                    |
 
 Panic if:
-* `$rd + imm + 8` overflows
-* `$rd + imm + 8 > VM_MAX_RAM`
-* The memory range `MEM[$rd + imm, 8]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + imm + 8` overflows
+* `$rA + imm + 8 > VM_MAX_RAM`
+* The memory range `MEM[$rA + imm, 8]`  does not pass [ownership check](./main.md#ownership)
 
 ## Contract Opcodes
 
@@ -801,15 +801,15 @@ All these opcodes advance the program counter `$pc` by `4` after performing thei
 |             |                                      |
 | ----------- | ------------------------------------ |
 | Description | Get block header hash.               |
-| Operation   | ```MEM[$rd, 32] = blockhash($rs);``` |
-| Syntax      | `blockhash $rd $rs`                  |
-| Encoding    | `0x00 rd rs - -`                     |
+| Operation   | ```MEM[$rA, 32] = blockhash($rB);``` |
+| Syntax      | `blockhash $rA $rB`                  |
+| Encoding    | `0x00 rA rB - -`                     |
 | Notes       |                                      |
 
 Panic if:
-* `$rd + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* The memory range `MEM[$rd, 32]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
 
 Block header hashes for blocks with height greater than or equal to current block height are zero (`0x00**32`).
 
@@ -818,13 +818,13 @@ Block header hashes for blocks with height greater than or equal to current bloc
 |             |                            |
 | ----------- | -------------------------- |
 | Description | Get Fuel block height.     |
-| Operation   | ```$rd = blockheight();``` |
-| Syntax      | `blockheight $rd`          |
-| Encoding    | `0x00 rd - - -`            |
+| Operation   | ```$rA = blockheight();``` |
+| Syntax      | `blockheight $rA`          |
+| Encoding    | `0x00 rA - - -`            |
 | Notes       |                            |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
+* `$rA` is a [reserved register](./main.md#semantics)
 
 ### CALL: Call contract
 
@@ -832,20 +832,20 @@ Panic if:
 | ----------- | ---------------------- |
 | Description | Call contract.         |
 | Operation   |                        |
-| Syntax      | `call $rs $rt $ru $rv` |
-| Encoding    | `0x00 rs rt ru rv`     |
+| Syntax      | `call $rA $rB $rC $rD` |
+| Encoding    | `0x00 rA rB rC rD`     |
 | Notes       |                        |
 
 Panic if:
-* `$rs + 32` overflows
-* `$ru + 32` overflows
-* Contract with ID `MEM[$rs, 32]` is not in `tx.inputs`
+* `$rA + 32` overflows
+* `$rC + 32` overflows
+* Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
 * Reading past `MEM[VM_MAX_RAM - 1]`
 * Any output range does not pass [ownership check](./main.md#ownership)
-* In an external context, if `$rt > MEM[balanceOf(MEM[$ru, 32]), 8]`
-* In an internal context, if `$rt` is greater than the balance of color `MEM[$ru, 32]` of output with contract ID `MEM[$rs, 32]`
+* In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`
+* In an internal context, if `$rB` is greater than the balance of color `MEM[$rC, 32]` of output with contract ID `MEM[$rA, 32]`
 
-Register `$rs` is a memory address from which the following fields are set (word-aligned):
+Register `$rA` is a memory address from which the following fields are set (word-aligned):
 
 | bytes | type                 | value             | description                                                      |
 | ----- | -------------------- | ----------------- | ---------------------------------------------------------------- |
@@ -855,16 +855,16 @@ Register `$rs` is a memory address from which the following fields are set (word
 | 16*   | `(uint32, uint32)[]` | out (addr, size)s | Array of memory addresses and lengths in bytes of return values. |
 | 16*   | `(uint32, uint32)[]` | in (addr, size)s  | Array of memory addresses and lengths in bytes of input values.  |
 
-`$rv` is the amount of gas to forward. If it is set to an amount greater than the available gas, all available gas is forwarded.
+`$rD` is the amount of gas to forward. If it is set to an amount greater than the available gas, all available gas is forwarded.
 
-For output with contract ID `MEM[$rs, 32]`, increase balance of color `MEM[$ru, 32]` by `$rt`. In an external context, decrease `MEM[balanceOfStart(MEM[$ru, 32]), 8]` by `$rt`. In an internal context, decrease color `MEM[$ru, 32]` balance of output with contract ID `MEM[$fp, 32]` by `$rt`.
+For output with contract ID `MEM[$rA, 32]`, increase balance of color `MEM[$rC, 32]` by `$rB`. In an external context, decrease `MEM[balanceOfStart(MEM[$rC, 32]), 8]` by `$rB`. In an internal context, decrease color `MEM[$rC, 32]` balance of output with contract ID `MEM[$fp, 32]` by `$rB`.
 
 A [call frame](./main.md#call-frames) is pushed at `$sp`. In addition to filling in the values of the call frame, the following registers are set:
 1. `$fp = $sp` (on top of the previous call frame is the beginning of this call frame)
 1. Set `$ssp` and `$sp` to the start of the writable stack area of the call frame.
 1. Set `$pc` and `$is` to the starting address of the code.
-1. `$bal = $rt` (forward coins)
-1. `$cgas = $rv` (forward gas)
+1. `$bal = $rD` (forward coins)
+1. `$cgas = $rD` or all available gas (forward gas)
 
 This modifies the `balanceRoot` field of the appropriate output(s).
 
@@ -872,38 +872,38 @@ This modifies the `balanceRoot` field of the appropriate output(s).
 
 |             |                                                                                                                                                  |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Description | Copy `$ru` bytes of code starting at `$rt` for contract with ID equal to the 32 bytes in memory starting at `$rs` into memory starting at `$rd`. |
-| Operation   | ```MEM[$rd, $ru] = code($rs, $rt, $ru);```                                                                                                       |
-| Syntax      | `codecopy $rd, $rs, $rt, $ru`                                                                                                                    |
-| Encoding    | `0x00 rd rs rt ru`                                                                                                                               |
-| Notes       | If `$ru` is greater than the code size, zero bytes are filled in.                                                                                |
+| Description | Copy `$rD` bytes of code starting at `$rC` for contract with ID equal to the 32 bytes in memory starting at `$rB` into memory starting at `$rA`. |
+| Operation   | ```MEM[$rA, $rD] = code($rB, $rC, $rD);```                                                                                                       |
+| Syntax      | `codecopy $rA, $rB, $rC, $rD`                                                                                                                    |
+| Encoding    | `0x00 rA rB rC rD`                                                                                                                               |
+| Notes       | If `$rD` is greater than the code size, zero bytes are filled in.                                                                                |
 
 Panic if:
-* `$rd + $ru` overflows
-* `$rs + 32` overflows
-* `$rd + $ru > VM_MAX_RAM`
-* `$rs + 32 > VM_MAX_RAM`
-* The memory range `MEM[$rd, $ru]`  does not pass [ownership check](./main.md#ownership)
-* `$ru > MEM_MAX_ACCESS_SIZE`
-* Contract with ID `MEM[$rs, 32]` is not in `tx.inputs`
+* `$rA + $rD` overflows
+* `$rB + 32` overflows
+* `$rA + $rD > VM_MAX_RAM`
+* `$rB + 32 > VM_MAX_RAM`
+* The memory range `MEM[$rA, $rD]`  does not pass [ownership check](./main.md#ownership)
+* `$rD > MEM_MAX_ACCESS_SIZE`
+* Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
 
 ### CODEROOT: Code Merkle root
 
 |             |                                                                                                                                       |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Description | Set the 32 bytes in memory starting at `$rd` to the code root for contract with ID equal to the 32 bytes in memory starting at `$rs`. |
-| Operation   | ```MEM[$rd, 32] = coderoot(MEM[$rs, 32]);```                                                                                          |
-| Syntax      | `coderoot $rd, $rs`                                                                                                                   |
-| Encoding    | `0x00 rd rs - -`                                                                                                                      |
+| Description | Set the 32 bytes in memory starting at `$rA` to the code root for contract with ID equal to the 32 bytes in memory starting at `$rB`. |
+| Operation   | ```MEM[$rA, 32] = coderoot(MEM[$rB, 32]);```                                                                                          |
+| Syntax      | `coderoot $rA, $rB`                                                                                                                   |
+| Encoding    | `0x00 rA rB - -`                                                                                                                      |
 | Notes       |                                                                                                                                       |
 
 Panic if:
-* `$rd + 32` overflows
-* `$rs + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$rs + 32 > VM_MAX_RAM`
-* The memory range `MEM[$rd, 32]`  does not pass [ownership check](./main.md#ownership)
-* Contract with ID `MEM[$rs, 32]` is not in `tx.inputs`
+* `$rA + 32` overflows
+* `$rB + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* `$rB + 32 > VM_MAX_RAM`
+* The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
+* Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
 
 Code root compuration is defined [here](../protocol/identifiers.md#contract-id).
 
@@ -911,55 +911,55 @@ Code root compuration is defined [here](../protocol/identifiers.md#contract-id).
 
 |             |                                                                                                           |
 | ----------- | --------------------------------------------------------------------------------------------------------- |
-| Description | Set `$rd` to the size of the code for contract with ID equal to the 32 bytes in memory starting at `$rs`. |
-| Operation   | ```$rd = codesize(MEM[$rs, 32]);```                                                                       |
-| Syntax      | `codesize $rd, $rs`                                                                                       |
-| Encoding    | `0x00 rd rs - -`                                                                                          |
+| Description | Set `$rA` to the size of the code for contract with ID equal to the 32 bytes in memory starting at `$rB`. |
+| Operation   | ```$rA = codesize(MEM[$rB, 32]);```                                                                       |
+| Syntax      | `codesize $rA, $rB`                                                                                       |
+| Encoding    | `0x00 rA rB - -`                                                                                          |
 | Notes       |                                                                                                           |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
-* `$rs + 32` overflows
-* `$rs + 32 > VM_MAX_RAM`
-* Contract with ID `MEM[$rs, 32]` is not in `tx.inputs`
+* `$rA` is a [reserved register](./main.md#semantics)
+* `$rB + 32` overflows
+* `$rB + 32 > VM_MAX_RAM`
+* Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
 
 ### COINBASE: Block proposer address
 
 |             |                                  |
 | ----------- | -------------------------------- |
 | Description | Get block proposer address.      |
-| Operation   | ```MEM[$rd, 32] = coinbase();``` |
-| Syntax      | `coinbase $rd`                   |
-| Encoding    | `0x00 rd - - -`                  |
+| Operation   | ```MEM[$rA, 32] = coinbase();``` |
+| Syntax      | `coinbase $rA`                   |
+| Encoding    | `0x00 rA - - -`                  |
 | Notes       |                                  |
 
 Panic if:
-* `$rd + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* The memory range `MEM[$rd, 32]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
 
 ### LOADCODE: Load code from an external contract
 
 |             |                                                                                                                                                   |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Description | Copy `$ru` bytes of code starting at `$rt` for contract with ID equal to the 32 bytes in memory starting at `$rs` into memory starting at `$ssp`. |
-| Operation   | ```MEM[$ssp, $ru] = code($rs, $rt, $ru);```                                                                                                       |
-| Syntax      | `loadcode $rs, $rt, $ru`                                                                                                                          |
-| Encoding    | `0x00 rs rt ru -`                                                                                                                                 |
-| Notes       | If `$ru` is greater than the code size, zero bytes are filled in.                                                                                 |
+| Description | Copy `$rC` bytes of code starting at `$rB` for contract with ID equal to the 32 bytes in memory starting at `$rA` into memory starting at `$ssp`. |
+| Operation   | ```MEM[$ssp, $rC] = code($rA, $rB, $rC);```                                                                                                       |
+| Syntax      | `loadcode $rA, $rB, $rC`                                                                                                                          |
+| Encoding    | `0x00 rA rB rC -`                                                                                                                                 |
+| Notes       | If `$rC` is greater than the code size, zero bytes are filled in.                                                                                 |
 
 Panic if:
-* `$ssp + $ru` overflows
-* `$rs + 32` overflows
-* `$ssp + $ru > VM_MAX_RAM`
-* `$rs + 32 > VM_MAX_RAM`
+* `$ssp + $rC` overflows
+* `$rA + 32` overflows
+* `$ssp + $rC > VM_MAX_RAM`
+* `$rA + 32 > VM_MAX_RAM`
 * `$ssp != $sp`
-* `$ssp + $ru > $hp`
-* `$ru > CONTRACT_MAX_SIZE`
-* `$ru > MEM_MAX_ACCESS_SIZE`
-* Contract with ID `MEM[$rs, 32]` is not in `tx.inputs`
+* `$ssp + $rC > $hp`
+* `$rC > CONTRACT_MAX_SIZE`
+* `$rC > MEM_MAX_ACCESS_SIZE`
+* Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
 
-Increment `$hp->codesize`, `$ssp`, and `$sp` by `$ru` padded to word alignment.
+Increment `$hp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word alignment.
 
 This opcode can be used to concatenate the code of multiple contracts together. It can only be used when the stack area of the call frame is unused (i.e. prior to being used).
 
@@ -968,19 +968,19 @@ This opcode can be used to concatenate the code of multiple contracts together. 
 |             |                                |
 | ----------- | ------------------------------ |
 | Description | Log an event. This is a no-op. |
-| Operation   | ```log($rs, $rt, $ru, $rv);``` |
-| Syntax      | `log $rs, $rt, $ru, $rv`       |
-| Encoding    | `0x00 rs rt ru rv`             |
+| Operation   | ```log($rA, $rB, $rC, $rD);``` |
+| Syntax      | `log $rA, $rB, $rC, $rD`       |
+| Encoding    | `0x00 rA rB rC rD`             |
 | Notes       |                                |
 
 ### REVERT: Revert
 
 |             |                                                                       |
 | ----------- | --------------------------------------------------------------------- |
-| Description | Halt execution, reverting state changes and returning value in `$rs`. |
-| Operation   | ```revert($rs);```                                                    |
-| Syntax      | `revert $rs`                                                          |
-| Encoding    | `0x00 rs - - -`                                                       |
+| Description | Halt execution, reverting state changes and returning value in `$rA`. |
+| Operation   | ```revert($rA);```                                                    |
+| Syntax      | `revert $rA`                                                          |
+| Encoding    | `0x00 rA - - -`                                                       |
 | Notes       |                                                                       |
 
 After a revert:
@@ -992,24 +992,24 @@ After a revert:
 
 |             |                                                                                                                 |
 | ----------- | --------------------------------------------------------------------------------------------------------------- |
-| Description | Copy `$ru` bytes of code starting at `$rt` for contract with static index `$rs` into memory starting at `$ssp`. |
-| Operation   | ```MEM[$ssp, $ru] = scode($rs, $rt, $ru);```                                                                    |
-| Syntax      | `sloadcode $rs, $rt, $ru`                                                                                       |
-| Encoding    | `0x00 rs rt ru -`                                                                                               |
-| Notes       | If `$ru` is greater than the code size, zero bytes are filled in.                                               |
+| Description | Copy `$rC` bytes of code starting at `$rB` for contract with static index `$rA` into memory starting at `$ssp`. |
+| Operation   | ```MEM[$ssp, $rC] = scode($rA, $rB, $rC);```                                                                    |
+| Syntax      | `sloadcode $rA, $rB, $rC`                                                                                       |
+| Encoding    | `0x00 rA rB rC -`                                                                                               |
+| Notes       | If `$rC` is greater than the code size, zero bytes are filled in.                                               |
 
 Panic if:
-* `$ssp + $ru` overflows
-* `$ssp + $ru > VM_MAX_RAM`
-* `$rs >= MAX_STATIC_CONTRACTS`
-* `$rs` is greater than or equal to `staticContractsCount` for the contract with ID `MEM[$rs, 32]`
+* `$ssp + $rC` overflows
+* `$ssp + $rC > VM_MAX_RAM`
+* `$rA >= MAX_STATIC_CONTRACTS`
+* `$rA` is greater than or equal to `staticContractsCount` for the contract with ID `MEM[$fp, 32]`
 * `$ssp != $sp`
-* `$ssp + $ru > $hp`
-* `$ru > CONTRACT_MAX_SIZE`
-* `$ru > MEM_MAX_ACCESS_SIZE`
-* Contract with ID `MEM[$rs, 32]` is not in `tx.inputs`
+* `$ssp + $rC > $hp`
+* `$rC > CONTRACT_MAX_SIZE`
+* `$rC > MEM_MAX_ACCESS_SIZE`
+* `$fp == 0` (in the script context)
 
-Increment `$hp->codesize`, `$ssp`, and `$sp` by `$ru` padded to word alignment.
+Increment `$hp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word alignment.
 
 This opcode can be used to concatenate the code of multiple contracts together. It can only be used when the stack area of the call frame is unused (i.e. prior to being used).
 
@@ -1018,15 +1018,15 @@ This opcode can be used to concatenate the code of multiple contracts together. 
 |             |                                                   |
 | ----------- | ------------------------------------------------- |
 | Description | A word is read from the current contract's state. |
-| Operation   | ```$rd = STATE[MEM[$rs, 32]][0, 8];```            |
-| Syntax      | `srw $rd, $rs`                                    |
-| Encoding    | `0x00 rd rs - -`                                  |
+| Operation   | ```$rA = STATE[MEM[$rB, 32]][0, 8];```            |
+| Syntax      | `srw $rA, $rB`                                    |
+| Encoding    | `0x00 rA rB - -`                                  |
 | Notes       | Returns zero if the state element does not exist. |
 
 Panic if:
-* `$rd` is a [reserved register](./main.md#semantics)
-* `$rs + 32` overflows
-* `$rs + 32 > VM_MAX_RAM`
+* `$rA` is a [reserved register](./main.md#semantics)
+* `$rB + 32` overflows
+* `$rB + 32 > VM_MAX_RAM`
 * `$fp == 0` (in the script context)
 
 ### SRWX: State read 32 bytes
@@ -1034,17 +1034,17 @@ Panic if:
 |             |                                                     |
 | ----------- | --------------------------------------------------- |
 | Description | 32 bytes is read from the current contract's state. |
-| Operation   | ```MEM[$rd, 32] = STATE[MEM[$rs, 32]];```           |
-| Syntax      | `srwx $rd, $rs`                                     |
-| Encoding    | `0x00 rd rs - -`                                    |
+| Operation   | ```MEM[$rA, 32] = STATE[MEM[$rB, 32]];```           |
+| Syntax      | `srwx $rA, $rB`                                     |
+| Encoding    | `0x00 rA rB - -`                                    |
 | Notes       | Returns zero if the state element does not exist.   |
 
 Panic if:
-* `$rd + 32` overflows
-* `$rs + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$rs + 32 > VM_MAX_RAM`
-* The memory range `MEM[$rd, 32]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + 32` overflows
+* `$rB + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* `$rB + 32 > VM_MAX_RAM`
+* The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
 * `$fp == 0` (in the script context)
 
 ### SWW: State write word
@@ -1052,14 +1052,14 @@ Panic if:
 |             |                                                    |
 | ----------- | -------------------------------------------------- |
 | Description | A word is written to the current contract's state. |
-| Operation   | ```STATE[MEM[$rd, 32]][0, 8] = $rs;```             |
-| Syntax      | `sww $rd $rs`                                      |
-| Encoding    | `0x00 rd rs - -`                                   |
+| Operation   | ```STATE[MEM[$rA, 32]][0, 8] = $rB;```             |
+| Syntax      | `sww $rA $rB`                                      |
+| Encoding    | `0x00 rA rB - -`                                   |
 | Notes       |                                                    |
 
 Panic if:
-* `$rd + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
+* `$rA + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
 * `$fp == 0` (in the script context)
 
 ### SWWX: State write 32 bytes
@@ -1067,41 +1067,41 @@ Panic if:
 |             |                                                      |
 | ----------- | ---------------------------------------------------- |
 | Description | 32 bytes is written to the current contract's state. |
-| Operation   | ```STATE[MEM[$rd, 32]] = MEM[$rs, 32];```            |
-| Syntax      | `swwx $rd, $rs`                                      |
-| Encoding    | `0x00 rd rs - -`                                     |
+| Operation   | ```STATE[MEM[$rA, 32]] = MEM[$rB, 32];```            |
+| Syntax      | `swwx $rA, $rB`                                      |
+| Encoding    | `0x00 rA rB - -`                                     |
 | Notes       |                                                      |
 
 Panic if:
-* `$rd + 32` overflows
-* `$rs + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$rs + 32 > VM_MAX_RAM`
+* `$rA + 32` overflows
+* `$rB + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* `$rB + 32 > VM_MAX_RAM`
 * `$fp == 0` (in the script context)
 
 ### TRANSFER: Transfer coins to contract
 
 |             |                                                                        |
 | ----------- | ---------------------------------------------------------------------- |
-| Description | Transfer `$rs` coins with color at `$rt` to contract with ID at `$rd`. |
-| Operation   | ```transfer(MEM[$rd, 32], $rs, MEM[$rt, 32]);```                       |
-| Syntax      | `transfer $rd, $rs, $rt`                                               |
-| Encoding    | `0x00 rd rs rt -`                                                      |
+| Description | Transfer `$rB` coins with color at `$rC` to contract with ID at `$rA`. |
+| Operation   | ```transfer(MEM[$rA, 32], $rB, MEM[$rC, 32]);```                       |
+| Syntax      | `transfer $rA, $rB, $rC`                                               |
+| Encoding    | `0x00 rA rB rC -`                                                      |
 | Notes       |                                                                        |
 
 Given helper `balanceOfStart(color: byte[32]) -> uint32` which returns the memory address of `color` balance, or `0` if `color` has no balance.
 
 Panic if:
-* `$rd + 32` overflows
-* `$rt + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$rt + 32 > VM_MAX_RAM`
-* Contract with ID `MEM[$rd, 32]` is not in `tx.inputs`
-* In an external context, if `$rs > MEM[balanceOf(MEM[$ru, 32]), 8]`
-* In an internal context, if `$rs` is greater than the balance of color `MEM[$rt, 32]` of output with contract ID `MEM[$fp, 32]`
-* `$rs == 0`
+* `$rA + 32` overflows
+* `$rC + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* `$rC + 32 > VM_MAX_RAM`
+* Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
+* In an external context, if `$rB > MEM[balanceOf(MEM[$rC, 32]), 8]`
+* In an internal context, if `$rB` is greater than the balance of color `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
+* `$rB == 0`
 
-For output with contract ID `MEM[$rd, 32]`, increase balance of color `MEM[$ru, 32]` by `$rt`. In an external context, decrease `MEM[balanceOfStart(MEM[$ru, 32]), 8]` by `$rt`. In an internal context, decrease color `MEM[$ru, 32]` balance of output with contract ID `MEM[$fp, 32]` by `$rt`.
+For output with contract ID `MEM[$rA, 32]`, increase balance of color `MEM[$rC, 32]` by `$rB`. In an external context, decrease `MEM[balanceOfStart(MEM[$rC, 32]), 8]` by `$rB`. In an internal context, decrease color `MEM[$rC, 32]` balance of output with contract ID `MEM[$fp, 32]` by `$rB`.
 
 This modifies the `balanceRoot` field of the appropriate output(s).
 
@@ -1109,30 +1109,30 @@ This modifies the `balanceRoot` field of the appropriate output(s).
 
 |             |                                                                                  |
 | ----------- | -------------------------------------------------------------------------------- |
-| Description | Transfer `$rt` coins with color at `$ru` to address at `$rd`, with output `$rs`. |
+| Description | Transfer `$rC` coins with color at `$rD` to address at `$rA`, with output `$rB`. |
 | Operation   | ```transferout(MEM[$rd, 32], $rs, $rt, MEM[$ru, 32]);```                         |
-| Syntax      | `transferout $rd, $rs, $rt, $ru`                                                 |
-| Encoding    | `0x00 rd rs rt ru`                                                               |
+| Syntax      | `transferout $rA, $rB, $rC, $rD`                                                 |
+| Encoding    | `0x00 rA rB rC rD`                                                               |
 | Notes       |                                                                                  |
 
 Given helper `balanceOfStart(color: byte[32]) -> uint32` which returns the memory address of `color` balance, or `0` if `color` has no balance.
 
 Panic if:
-* `$rd + 32` overflows
-* `$ru + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$ru + 32 > VM_MAX_RAM`
-* `$rs > tx.outputsCount`
-* In an external context, if `$rt > MEM[balanceOf(MEM[$ru, 32]), 8]`
-* In an internal context, if `$rt` is greater than the balance of color `MEM[$ru, 32]` of output with contract ID `MEM[$fp, 32]`
-* `$rt == 0`
-* `tx.outputs[$rs].type != OutputType.Variable`
-* `tx.outputs[$rs].amount != 0`
+* `$rA + 32` overflows
+* `$rD + 32` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* `$rD + 32 > VM_MAX_RAM`
+* `$rB > tx.outputsCount`
+* In an external context, if `$rC > MEM[balanceOf(MEM[$rD, 32]), 8]`
+* In an internal context, if `$rC` is greater than the balance of color `MEM[$rD, 32]` of output with contract ID `MEM[$fp, 32]`
+* `$rC == 0`
+* `tx.outputs[$rB].type != OutputType.Variable`
+* `tx.outputs[$rB].amount != 0`
 
-In an external context, decrease `MEM[balanceOfStart(MEM[$ru, 32]), 8]` by `$rt`. In an internal context, decrease color `MEM[$ru, 32]` balance of output with contract ID `MEM[$fp, 32]` by `$rt`. Then set:
-* `tx.outputs[$rs].to = MEM[$rd, 32]`
-* `tx.outputs[$rs].amount = $rt`
-* `tx.outputs[$rs].color = MEM[$ru, 32]`
+In an external context, decrease `MEM[balanceOfStart(MEM[$rD, 32]), 8]` by `$rC`. In an internal context, decrease color `MEM[$rD, 32]` balance of output with contract ID `MEM[$fp, 32]` by `$rC`. Then set:
+* `tx.outputs[$rB].to = MEM[$rA, 32]`
+* `tx.outputs[$rB].amount = $rC`
+* `tx.outputs[$rB].color = MEM[$rD, 32]`
 
 This modifies the `balanceRoot` field of the appropriate output(s).
 
@@ -1142,20 +1142,20 @@ This modifies the `balanceRoot` field of the appropriate output(s).
 
 |             |                                                                                                                             |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rs` on 32-byte message hash starting at `$rt`. |
-| Operation   | ```MEM[$rd, 64] = ecrecover(MEM[$rs, 64], MEM[$rt, 32]);```                                                                 |
-| Syntax      | `ecrecover $rd, $rs, $rt`                                                                                                   |
-| Encoding    | `0x00 rd rs rt -`                                                                                                           |
+| Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
+| Operation   | ```MEM[$rA, 64] = ecrecover(MEM[$rB, 64], MEM[$rC, 32]);```                                                                 |
+| Syntax      | `ecrecover $rA, $rB, $rC`                                                                                                   |
+| Encoding    | `0x00 rA rB rC -`                                                                                                           |
 | Notes       |                                                                                                                             |
 
 Panic if:
-* `$rd + 64` overflows
-* `$rs + 64` overflows
-* `$rt + 32` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$rs + 64 > VM_MAX_RAM`
-* `$rt + 32 > VM_MAX_RAM`
-* The memory range `MEM[$rd, 64]`  does not pass [ownership check](./main.md#ownership)
+* `$rA + 64` overflows
+* `$rB + 64` overflows
+* `$rC + 32` overflows
+* `$rA + 64 > VM_MAX_RAM`
+* `$rB + 64 > VM_MAX_RAM`
+* `$rC + 32 > VM_MAX_RAM`
+* The memory range `MEM[$rA, 64]`  does not pass [ownership check](./main.md#ownership)
 
 To get the address, hash the public key with [SHA-2-256](#sha256-sha-2-256).
 
@@ -1163,37 +1163,37 @@ To get the address, hash the public key with [SHA-2-256](#sha256-sha-2-256).
 
 |             |                                                       |
 | ----------- | ----------------------------------------------------- |
-| Description | The keccak-256 hash of `$rt` bytes starting at `$rs`. |
-| Operation   | ```MEM[$rd, 32] = keccak256(MEM[$rs, $rt]);```        |
-| Syntax      | `keccak256 $rd, $rs, $rt`                             |
-| Encoding    | `0x00 rd rs rt -`                                     |
+| Description | The keccak-256 hash of `$rC` bytes starting at `$rB`. |
+| Operation   | ```MEM[$rA, 32] = keccak256(MEM[$rB, $rC]);```        |
+| Syntax      | `keccak256 $rA, $rB, $rC`                             |
+| Encoding    | `0x00 rA rB rC -`                                     |
 | Notes       |                                                       |
 
 Panic if:
-* `$rd + 64` overflows
-* `$rs + $rt` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$rs + $rt > VM_MAX_RAM`
-* The memory range `MEM[$rd, 32]`  does not pass [ownership check](./main.md#ownership)
-* `$rt > MEM_MAX_ACCESS_SIZE`
+* `$rA + 32` overflows
+* `$rB + $rC` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* `$rB + $rC > VM_MAX_RAM`
+* The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
+* `$rC > MEM_MAX_ACCESS_SIZE`
 
 ### SHA256: SHA-2-256
 
 |             |                                                      |
 | ----------- | ---------------------------------------------------- |
-| Description | The SHA-2-256 hash of `$rt` bytes starting at `$rs`. |
-| Operation   | ```MEM[$rd, 32] = sha256(MEM[$rs, $rt]);```          |
-| Syntax      | `sha256 $rd, $rs, $rt`                               |
-| Encoding    | `0x00 rd rs rt -`                                    |
+| Description | The SHA-2-256 hash of `$rC` bytes starting at `$rB`. |
+| Operation   | ```MEM[$rA, 32] = sha256(MEM[$rB, $rC]);```          |
+| Syntax      | `sha256 $rA, $rB, $rC`                               |
+| Encoding    | `0x00 rA rB rC -`                                    |
 | Notes       |                                                      |
 
 Panic if:
-* `$rd + 64` overflows
-* `$rs + $rt` overflows
-* `$rd + 32 > VM_MAX_RAM`
-* `$rs + $rt > VM_MAX_RAM`
-* The memory range `MEM[$rd, 32]`  does not pass [ownership check](./main.md#ownership)
-* `$rt > MEM_MAX_ACCESS_SIZE`
+* `$rA + 32` overflows
+* `$rB + $rC` overflows
+* `$rA + 32 > VM_MAX_RAM`
+* `$rB + $rC > VM_MAX_RAM`
+* The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
+* `$rC > MEM_MAX_ACCESS_SIZE`
 
 ## Other Opcodes
 
@@ -1201,8 +1201,8 @@ Panic if:
 
 |             |                       |
 | ----------- | --------------------- |
-| Description | Set `$flag` to `$rs`. |
-| Operation   | ```$flag = $rs;```    |
-| Syntax      | `flag $rs`            |
-| Encoding    | `0x00 rs - - -`       |
+| Description | Set `$flag` to `$rA`. |
+| Operation   | ```$flag = $rA;```    |
+| Syntax      | `flag $rA`            |
+| Encoding    | `0x00 rA - - -`       |
 | Notes       |                       |


### PR DESCRIPTION
From `{rd, rs, rt, ru, rv}` to `{rA, rB, rC, rD}`.

Also make a few fixes to incorrect registers and checks.