### PR TITLE
Make maturity fields 32 bits

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -70,7 +70,7 @@ When deserializing a transaction, the reverse is done. If there are insufficient
 |--------------------|-------------------------|------------------------------------------|
 | `gasPrice`         | `uint64`                | Gas price for transaction.               |
 | `gasLimit`         | `uint64`                | Gas limit for transaction.               |
-| `maturity`         | `uint64`                | Block until which tx cannot be included. |
+| `maturity`         | `uint32`                | Block until which tx cannot be included. |
 | `scriptLength`     | `uint16`                | Script length, in instructions.          |
 | `scriptDataLength` | `uint16`                | Length of script input data, in bytes.   |
 | `inputsCount`      | `uint8`                 | Number of inputs.                        |
@@ -94,7 +94,7 @@ Transaction is invalid if:
 |------------------------|-------------------------|-----------------------------------------------|
 | `gasPrice`             | `uint64`                | Gas price for transaction.                    |
 | `gasLimit`             | `uint64`                | Gas limit for transaction.                    |
-| `maturity`             | `uint64`                | Block until which tx cannot be included.      |
+| `maturity`             | `uint32`                | Block until which tx cannot be included.      |
 | `bytecodeLength`       | `uint16`                | Contract bytecode length, in instructions.    |
 | `bytecodeWitnessIndex` | `uint8`                 | Witness index of contract bytecode to create. |
 | `staticContractsCount` | `uint8`                 | Number of static contracts.                   |


### PR DESCRIPTION
Block heights are 32 bits, not 64 bits