### PR TITLE
Fix color and contract ID compression

### DIFF
--- a/specs/protocol/compressed_tx_format.md
+++ b/specs/protocol/compressed_tx_format.md
@@ -150,9 +150,9 @@ This document specifies the _compressed_ transaction format, which is posted to 
 
 ### OutputContractCreated
 
-| name         | type       | description  |
-|--------------|------------|--------------|
-| `contractID` | `byte[32]` | Contract ID. |
+| name                | type                    | description          |
+|---------------------|-------------------------|----------------------|
+| `contractIDPointer` | `DigestRegistryPointer` | Contract ID pointer. |
 
 ## Witness
 


### PR DESCRIPTION
Fixes #141.

- Use a uniform `DigestRegistryPointer` for colors and addresses.
- Use a UTXO pointer instead of contract ID pointer when spending a contract UTXO (knowing the contract ID isn't sufficient information, but knowing the exact UTXO is).