### PR TITLE
Reduce max static contracts to `255`

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -28,7 +28,7 @@
 | `MAX_PREDICATE_DATA_LENGTH` | `uint64` |       | Maximum length of predicate data, in bytes.   |
 | `MAX_SCRIPT_LENGTH`         | `uint64` |       | Maximum length of script, in instructions.    |
 | `MAX_SCRIPT_DATA_LENGTH`    | `uint64` |       | Maximum length of script data, in bytes.      |
-| `MAX_STATIC_CONTRACTS`      | `uint64` | `256` | Maximum number of static contracts.           |
+| `MAX_STATIC_CONTRACTS`      | `uint64` | `255` | Maximum number of static contracts.           |
 | `MAX_WITNESSES`             | `uint64` | `16`  | Maximum number of witnesses.                  |
 
 ## Transaction


### PR DESCRIPTION
This allows the number to fit into a `u8`, as per https://github.com/FuelLabs/fuel-tx/pull/4#discussion_r634679120.