### PR TITLE
Fix contract output init for predicates

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -180,7 +180,7 @@ Transaction is invalid if:
 
 Note: when signing a transaction, `utxoID`, `balanceRoot`, and `stateRoot` are set to zero.
 
-Note: when verifying a predicate, `utxoID`, `balanceRoot`, and `stateRoot` is initialized to zero.
+Note: when verifying a predicate, `utxoID`, `balanceRoot`, and `stateRoot` are initialized to zero.
 
 Note: when executing a script, `utxoID`, `balanceRoot`, and `stateRoot` are initialized to the UTXO ID, amount, and state root of the contract with ID `contractID`.
 


### PR DESCRIPTION
Predicate verification must be monotonic, therefore cannot have access to contract state root or balance root.