### PR TITLE
Make `LW` and `SW` immediates be multiples of word size

### DIFF
--- a/specs/vm/opcodes.md
+++ b/specs/vm/opcodes.md
@@ -769,7 +769,7 @@ Panic if:
 |             |                                                              |
 |-------------|--------------------------------------------------------------|
 | Description | A word is loaded from the specified address offset by `imm`. |
-| Operation   | ```$rA = MEM[$rB + imm, 8];```                               |
+| Operation   | ```$rA = MEM[$rB + (imm * 8), 8];```                         |
 | Syntax      | `lw $rA, $rB, imm`                                           |
 | Encoding    | `0x00 rA rB i i`                                             |
 | Notes       |                                                              |
@@ -777,8 +777,8 @@ Panic if:
 Panic if:
 
 - `$rA` is a [reserved register](./main.md#semantics)
-- `$rB + imm + 8` overflows
-- `$rB + imm + 8 > VM_MAX_RAM`
+- `$rB + (imm * 8) + 8` overflows
+- `$rB + (imm * 8) + 8 > VM_MAX_RAM`
 
 ### MCL: Memory clear
 
@@ -874,16 +874,16 @@ Panic if:
 |             |                                                                    |
 |-------------|--------------------------------------------------------------------|
 | Description | The value of `$rB` is stored at the address `$rA` offset by `imm`. |
-| Operation   | ```MEM[$rA + imm, 8] = $rB;```                                     |
+| Operation   | ```MEM[$rA + (imm * 8), 8] = $rB;```                               |
 | Syntax      | `sw $rA, $rB, imm`                                                 |
 | Encoding    | `0x00 rA rB i i`                                                   |
 | Notes       |                                                                    |
 
 Panic if:
 
-- `$rA + imm + 8` overflows
-- `$rA + imm + 8 > VM_MAX_RAM`
-- The memory range `MEM[$rA + imm, 8]`  does not pass [ownership check](./main.md#ownership)
+- `$rA + (imm * 8) + 8` overflows
+- `$rA + (imm * 8) + 8 > VM_MAX_RAM`
+- The memory range `MEM[$rA + (imm * 8), 8]`  does not pass [ownership check](./main.md#ownership)
 
 ## Contract Opcodes
 


### PR DESCRIPTION
Make `LW` and `SW` immediate values be multiples of `8` instead of individual bytes. This is because the high-level language is expected to word-align things like stack variables.

Note that all memory pointing registers still point to exact bytes instead of words. E.g. `$is` will point to the starting _byte_ of the instructions, and `$pc` will point to the current _byte_ of instruction being executed.