### PR TITLE
Fix mint and burn to use current contract ID

### DIFF
--- a/specs/vm/opcodes.md
+++ b/specs/vm/opcodes.md
@@ -952,10 +952,10 @@ Block header hashes for blocks with height greater than or equal to current bloc
 
 Panic if:
 
-- Balance of color `MEM[$fp + 32, 32]` of output with contract ID `MEM[$fp, 32]` minus `$rA` underflows
+- Balance of color `MEM[$fp, 32]` of output with contract ID `MEM[$fp, 32]` minus `$rA` underflows
 - `$fp == 0` (in the script context)
 
-For output with contract ID `MEM[$fp, 32]`, decrease balance of color `MEM[$fp + 32, 32]` by `$rA`.
+For output with contract ID `MEM[$fp, 32]`, decrease balance of color `MEM[$fp, 32]` by `$rA`.
 
 This modifies the `balanceRoot` field of the appropriate output.
 
@@ -1137,10 +1137,10 @@ Logs the memory range `MEM[$rC, $rD]`.
 
 Panic if:
 
-- Balance of color `MEM[$fp + 32, 32]` of output with contract ID `MEM[$fp, 32]` plus `$rA` overflows
+- Balance of color `MEM[$fp, 32]` of output with contract ID `MEM[$fp, 32]` plus `$rA` overflows
 - `$fp == 0` (in the script context)
 
-For output with contract ID `MEM[$fp, 32]`, increase balance of color `MEM[$fp + 32, 32]` by `$rA`.
+For output with contract ID `MEM[$fp, 32]`, increase balance of color `MEM[$fp, 32]` by `$rA`.
 
 This modifies the `balanceRoot` field of the appropriate output.
 


### PR DESCRIPTION
Instead of using the color of the forwarded coins, use the current contract ID as the color of the minted/burned coins.