### PR TITLE
Init heap pointer at top instead of frame pointer

### DIFF
--- a/specs/vm/main.md
+++ b/specs/vm/main.md
@@ -86,8 +86,7 @@ Then the following registers are initialized (without explicit initialization, a
 
 1. `$ssp = 32 + MAX_INPUTS*(32+8) + size(tx))`: the writable stack area starts immediately after the serialized transaction in memory (see above).
 1. `$sp = $ssp`: writable stack area is empty to start.
-1. `$fp = VM_MAX_RAM - 1`: the heap area begins at the top.
-1. `$hp = $fp`: heap area is empty to start.
+1. `$hp = VM_MAX_RAM - 1`: the heap area begins at the top and is empty to start.
 
 ## Contexts
 


### PR DESCRIPTION
I have no idea how I didn't notice, but the heap pointer is what should be initialized to the top of the memory, not the frame pointer. The frame pointer should be zero on VM initialization.