### PR TITLE
Add ABI link to README and change opcodes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This repository specifies the Fuel protocol, including the Fuel Virtual Machine (FuelVM, FVM), a next-generation verifiable virtual machine for [the Fuel v2 blockchain](https://github.com/FuelLabs).
 
-- [Specification](#specification)
-  - [Protocol](#protocol)
-  - [FuelVM](#fuelvm)
+- [Fuel Specifications](#fuel-specifications)
+  - [Specification](#specification)
+    - [Protocol](#protocol)
+    - [FuelVM](#fuelvm)
+  - [Contributing](#contributing)
 
 ## Specification
 
@@ -15,6 +17,7 @@ This repository specifies the Fuel protocol, including the Fuel Virtual Machine 
 1. [identifiers.md](./specs/protocol/identifiers.md): How to compute unique IDs for transactions and UTXOs.
 1. [tx_validity.md](./specs/protocol/tx_validity.md): Defines transaction validity rules.
 1. [cryptographic_primitives](./specs/protocol/cryptographic_primitives.md): Cryptographic primitives used in Fuel.
+1. [abi.md](./specs/protocol/abi.md): ABI specifications.
 
 ### FuelVM
 

--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -66,7 +66,7 @@ All receipts will have a `type` property:
   - "Transfer"
   - "TransferOut"
 
-Then, each receipt type will have its own properties. Some of these properties are related to the FuelVM's registers, as specified in more detail [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/opcodes.md).
+Then, each receipt type will have its own properties. Some of these properties are related to the FuelVM's registers, as specified in more detail [here](../vm/opcodes.md).
 
 _Important note:_ For the JSON representation of receipts, we represent 64-bit unsigned integers as a JSON `String` due to limitations around the type `Number` in the JSON specification, which only supports numbers up to `2^{53-1}`, while the FuelVM's registers hold values up to `2^64`.
 


### PR DESCRIPTION
- Adds the newly merged ABI doc to the entry document (`README.md`);
- Changes the way we're linking the opcode specs doc in the abi specs doc, it fixes that annoying broken URL issue we're seeing on the CI.