### PR TITLE
Add BAL balance opcode

### DIFF
--- a/specs/vm/opcodes.md
+++ b/specs/vm/opcodes.md
@@ -996,7 +996,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC + 32` overflows


### PR DESCRIPTION
Address #225.

- The order of the color and contract ID operands feel a little backwards from the `TR` and `TRO` opcodes. But this seems to make more sense if we want to add a `SELFBAL` opcode in the future for getting the balance of the current contract ID, where we would just drop the contract ID argument.
- There's some complexity around balances and contract outputs I haven't wrapped my head around yet, so might be missing something here.