### PR TITLE
Fix formatting of panic reasons

### DIFF
--- a/specs/vm/opcodes.md
+++ b/specs/vm/opcodes.md
@@ -122,7 +122,7 @@ In a script transaction, if there is an attempt to write to `$rA` that is a [res
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ReservedRegisterNotWritable \| rA >> 8`                    |
+| `result`   | `uint64`      | ```PanicReason.ReservedRegisterNotWritable \| rA >> 8```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 In a script transaction, if a memory range `MEM[$rX, $rY]` does not pass [ownership check](./main.md#ownership), append an additional receipt to the list of receipts, modifying `tx.receiptsRoot`:
@@ -130,7 +130,7 @@ In a script transaction, if a memory range `MEM[$rX, $rY]` does not pass [owners
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOwnership \| rX >> 8 \| rY >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOwnership \| rX >> 8 \| rY >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 In a script transaction, if `$err` is set, append an additional receipt to the list of receipts, modifying `tx.receiptsRoot`:
@@ -138,7 +138,7 @@ In a script transaction, if `$err` is set, append an additional receipt to the l
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ErrorFlag`                                                 |
+| `result`   | `uint64`      | ```PanicReason.ErrorFlag```                                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ## Arithmetic/Logic (ALU) Opcodes
@@ -154,7 +154,7 @@ In a script transaction, in case of overflow, append an additional receipt to th
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ArithmeticOverflow`                                        |
+| `result`   | `uint64`      | ```PanicReason.ArithmeticOverflow```                                    |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### ADD: Add
@@ -701,7 +701,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.TransactionMaturity \| rB >> 8 \| rC >> 14`                |
+| `result`   | `uint64`      | ```PanicReason.TransactionMaturity \| rB >> 8 \| rC >> 14```            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - the input `$rB` is not of type [`InputType.Coin`](../protocol/tx_format.md)
@@ -711,7 +711,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedCoinInput \| rB >> 8`                              |
+| `result`   | `uint64`      | ```PanicReason.ExpectedCoinInput \| rB >> 8```                          |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB > tx.inputsCount`
@@ -721,7 +721,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InputNotFound \| rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.InputNotFound \| rB >> 8```                              |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Otherwise, advance the program counter `$pc` by `4`.
@@ -748,7 +748,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.TransactionMaturity \| rB >> 8`                            |
+| `result`   | `uint64`      | ```PanicReason.TransactionMaturity \| rB >> 8```                        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Otherwise, advance the program counter `$pc` by `4`.
@@ -774,7 +774,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| imm >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| imm >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### JNEI: Jump if not equal immediate
@@ -796,7 +796,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| imm >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| imm >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### RET: Return from context
@@ -867,7 +867,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$hp - $rA < $sp`
@@ -877,7 +877,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### CFEI: Extend call frame immediate
@@ -899,7 +899,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| imm >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| imm >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$sp + imm > $hp`
@@ -909,7 +909,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| imm >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| imm >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### CFSI: Shrink call frame immediate
@@ -931,7 +931,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| imm >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| imm >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$sp - imm < $ssp`
@@ -941,7 +941,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| imm >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| imm >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### LB: Load byte
@@ -964,7 +964,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + imm + 1 > VM_MAX_RAM`
@@ -974,7 +974,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### LW: Load word
@@ -997,7 +997,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + (imm * 8) + 8 > VM_MAX_RAM`
@@ -1007,7 +1007,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### MCL: Memory clear
@@ -1030,7 +1030,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8 \| rB >> 14`                     |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| rB >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB > MEM_MAX_ACCESS_SIZE`
@@ -1040,7 +1040,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess \| rB >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rB >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, $rB]`  does not pass [ownership check](./main.md#ownership)
@@ -1065,7 +1065,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `imm > MEM_MAX_ACCESS_SIZE`
@@ -1075,7 +1075,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess \| imm >> 8`                               |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| imm >> 8```                           |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, imm]`  does not pass [ownership check](./main.md#ownership)
@@ -1101,7 +1101,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8 \| rC >> 14`                     |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| rC >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + $rC > VM_MAX_RAM`
@@ -1111,7 +1111,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8 \| rC >> 14`                     |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| rC >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC > MEM_MAX_ACCESS_SIZE`
@@ -1121,7 +1121,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess \| rC >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rC >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory ranges `MEM[$rA, $rC]` and `MEM[$rB, $rC]` overlap
@@ -1131,7 +1131,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryWriteOverlap \| rA >> 8 \| rB >> 14 \| rC >> 20`     |
+| `result`   | `uint64`      | ```PanicReason.MemoryWriteOverlap \| rA >> 8 \| rB >> 14 \| rC >> 20```   |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, $rC]`  does not pass [ownership check](./main.md#ownership)
@@ -1157,7 +1157,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + imm > VM_MAX_RAM`
@@ -1167,7 +1167,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `imm > MEM_MAX_ACCESS_SIZE`
@@ -1177,7 +1177,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess \| imm >> 8`                               |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| imm >> 8```                           |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory ranges `MEM[$rA, imm]` and `MEM[$rB, imm]` overlap
@@ -1187,7 +1187,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryWriteOverlap \| rA >> 8 \| rB >> 14 \| imm >> 20`    |
+| `result`   | `uint64`      | ```PanicReason.MemoryWriteOverlap \| rA >> 8 \| rB >> 14 \| imm >> 20```   |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, imm]`  does not pass [ownership check](./main.md#ownership)
@@ -1214,7 +1214,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8 \| rD >> 14`                     |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| rD >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC + $rD > VM_MAX_RAM`
@@ -1224,7 +1224,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rC >> 8 \| rD >> 14`                     |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rC >> 8 \| rD >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rD > MEM_MAX_ACCESS_SIZE`
@@ -1234,7 +1234,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess \| rD >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rD >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### SB: Store byte
@@ -1257,7 +1257,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA + imm, 1]`  does not pass [ownership check](./main.md#ownership)
@@ -1282,7 +1282,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14`                    |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| imm >> 14```                |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA + (imm * 8), 8]`  does not pass [ownership check](./main.md#ownership)
@@ -1325,7 +1325,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
@@ -1352,7 +1352,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext`                                   |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 For output with contract ID `MEM[$fp, 32]`, decrease balance of color `MEM[$fp, 32]` by `$rA`.
@@ -1380,7 +1380,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractNotInInputs \| rA >> 8`                            |
+| `result`   | `uint64`      | ```PanicReason.ContractNotInInputs \| rA >> 8```                        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - Reading past `MEM[VM_MAX_RAM - 1]`
@@ -1390,7 +1390,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`
@@ -1400,7 +1400,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InternalBalanceOverflow \| rB >> 8 \| rC >> 14`            |
+| `result`   | `uint64`      | ```PanicReason.InternalBalanceOverflow \| rB >> 8 \| rC >> 14```        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - In an internal context, if `$rB` is greater than the balance of color `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
@@ -1410,7 +1410,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InternalBalanceOverflow \| rB >> 8 \| rC >> 14`            |
+| `result`   | `uint64`      | ```PanicReason.InternalBalanceOverflow \| rB >> 8 \| rC >> 14```        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Register `$rA` is a memory address from which the following fields are set (word-aligned):
@@ -1470,7 +1470,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
@@ -1499,7 +1499,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8 \| rD >> 14`                     |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| rD >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + 32 > VM_MAX_RAM`
@@ -1509,7 +1509,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, $rD]`  does not pass [ownership check](./main.md#ownership)
@@ -1520,7 +1520,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess \| rD >> 8`                                |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rD >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
@@ -1530,7 +1530,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractNotInInputs \| rB >> 8`                            |
+| `result`   | `uint64`      | ```PanicReason.ContractNotInInputs \| rB >> 8```                        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### CROO: Code Merkle root
@@ -1554,7 +1554,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + 32 > VM_MAX_RAM`
@@ -1564,7 +1564,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
@@ -1575,7 +1575,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractNotInInputs \| rB >> 8`                            |
+| `result`   | `uint64`      | ```PanicReason.ContractNotInInputs \| rB >> 8```                        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Code root computation is defined [here](../protocol/identifiers.md#contract-id).
@@ -1601,7 +1601,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rB >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
@@ -1611,7 +1611,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractNotInInputs \| rB >> 8`                            |
+| `result`   | `uint64`      | ```PanicReason.ContractNotInInputs \| rB >> 8```                        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### LDC: Load code from an external contract
@@ -1635,7 +1635,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rC >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rC >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rA + 32 > VM_MAX_RAM`
@@ -1645,7 +1645,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow \| rA >> 8`                               |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$ssp != $sp`
@@ -1655,7 +1655,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedUnallocatedStack`                                  |
+| `result`   | `uint64`      | ```PanicReason.ExpectedUnallocatedStack```                              |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$ssp + $rC > $hp`
@@ -1665,7 +1665,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rC >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rC >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC > CONTRACT_MAX_SIZE`
@@ -1675,7 +1675,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractMaxSize | rC >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.ContractMaxSize \| rC >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC > MEM_MAX_ACCESS_SIZE`
@@ -1685,7 +1685,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess | rC >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rC >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
@@ -1695,7 +1695,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractNotInInputs | rC >> 8`                             |
+| `result`   | `uint64`      | ```PanicReason.ContractNotInInputs \| rC >> 8```                        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Increment `$fp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word alignment.
@@ -1770,7 +1770,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InternalBalanceOverflow | rA >> 8`                         |
+| `result`   | `uint64`      | ```PanicReason.InternalBalanceOverflow \| rA >> 8```                    |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$fp == 0` (in the script context)
@@ -1780,7 +1780,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext`                                   |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 For output with contract ID `MEM[$fp, 32]`, increase balance of color `MEM[$fp, 32]` by `$rA`.
@@ -1807,7 +1807,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8 | rB >> 14`                       |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8 \| rB >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB > MEM_MAX_ACCESS_SIZE`
@@ -1817,7 +1817,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess | rB >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rB >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
@@ -1882,7 +1882,7 @@ If current context is a script, append an additional receipt to the list of rece
 | name       | type          | description                                                               |
 |------------|---------------|---------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                                |
-| `result`   | `uint64`      | `PanicReason.Revert`                                                      |
+| `result`   | `uint64`      | ```PanicReason.Revert```                                                    |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                               |
 
 Cease VM execution and revert script effects. After a revert:
@@ -1911,7 +1911,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rC >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rC >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rA >= MAX_STATIC_CONTRACTS`
@@ -1921,7 +1921,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxStaticContractsReached | rA >> 8`                       |
+| `result`   | `uint64`      | ```PanicReason.MaxStaticContractsReached \| rA >> 8```                  |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rA` is greater than or equal to `staticContractsCount` for the contract with ID `MEM[$fp, 32]`
@@ -1931,7 +1931,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxStaticContractsReached | rA >> 8`                       |
+| `result`   | `uint64`      | ```PanicReason.MaxStaticContractsReached | rA >> 8```                      |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$ssp != $sp`
@@ -1941,7 +1941,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedUnallocatedStack`                                  |
+| `result`   | `uint64`      | ```PanicReason.ExpectedUnallocatedStack```                              |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$ssp + $rC > $hp`
@@ -1951,7 +1951,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rC >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rC >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC > CONTRACT_MAX_SIZE`
@@ -1961,7 +1961,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractMaxSize | rC >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.ContractMaxSize \| rC >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC > MEM_MAX_ACCESS_SIZE`
@@ -1971,7 +1971,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess | rC >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rC >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$fp == 0` (in the script context)
@@ -1981,7 +1981,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext                                    |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Increment `$hp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word alignment.
@@ -2009,7 +2009,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$fp == 0` (in the script context)
@@ -2019,7 +2019,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext                                    |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### SRWQ: State read 32 bytes
@@ -2043,7 +2043,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + 32 > VM_MAX_RAM`
@@ -2053,7 +2053,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
@@ -2064,7 +2064,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext                                    |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### SWW: State write word
@@ -2087,7 +2087,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$fp == 0` (in the script context)
@@ -2097,7 +2097,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext                                    |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 The last 24 bytes of `STATE[MEM[$rA, 32]]` are set to `0`.
@@ -2123,7 +2123,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + 32 > VM_MAX_RAM`
@@ -2133,7 +2133,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$fp == 0` (in the script context)
@@ -2143,7 +2143,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext                                    |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### TR: Transfer coins to contract
@@ -2169,7 +2169,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC + 32 > VM_MAX_RAM`
@@ -2179,7 +2179,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rC >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rC >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
@@ -2189,7 +2189,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ContractNotInInputs | rA >> 8`                             |
+| `result`   | `uint64`      | ```PanicReason.ContractNotInInputs \| rA >> 8```                        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - In an external context, if `$rB > MEM[balanceOf(MEM[$rC, 32]), 8]`
@@ -2199,7 +2199,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InternalBalanceOverflow | rB >> 8 | rC >> 14`              |
+| `result`   | `uint64`      | ```PanicReason.InternalBalanceOverflow \| rB >> 8 \| rC >> 14```        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - In an internal context, if `$rB` is greater than the balance of color `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
@@ -2209,7 +2209,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InternalBalanceOverflow | rB >> 8 | rC >> 14`              |
+| `result`   | `uint64`      | ```PanicReason.InternalBalanceOverflow \| rB >> 8 \| rC >> 14```        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB == 0`
@@ -2219,7 +2219,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.TransferAmountCannotBeZero`                                |
+| `result`   | `uint64`      | ```PanicReason.TransferAmountCannotBeZero```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
@@ -2261,7 +2261,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rD + 32 > VM_MAX_RAM`
@@ -2271,7 +2271,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rD >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rD >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB > tx.outputsCount`
@@ -2281,7 +2281,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.OutputNotFound | rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.OutputNotFound \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - In an external context, if `$rC > MEM[balanceOf(MEM[$rD, 32]), 8]`
@@ -2291,7 +2291,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InternalBalanceOverflow | rC >> 8 | rD >> 14`              |
+| `result`   | `uint64`      | ```PanicReason.InternalBalanceOverflow \| rC >> 8 \| rD >> 14```        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - In an internal context, if `$rC` is greater than the balance of color `MEM[$rD, 32]` of output with contract ID `MEM[$fp, 32]`
@@ -2301,7 +2301,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InternalBalanceOverflow | rC >> 8 | rD >> 14`              |
+| `result`   | `uint64`      | ```PanicReason.InternalBalanceOverflow \| rC >> 8 \| rD >> 14```        |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC == 0`
@@ -2311,7 +2311,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.TransferAmountCannotBeZero`                                |
+| `result`   | `uint64`      | ```PanicReason.TransferAmountCannotBeZero```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `tx.outputs[$rB].type != OutputType.Variable`
@@ -2321,7 +2321,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedOutputVariable | rB >> 8`                          |
+| `result`   | `uint64`      | ```PanicReason.ExpectedOutputVariable \| rB >> 8```                     |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `tx.outputs[$rB].amount != 0`
@@ -2331,7 +2331,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.TransferAmountCannotBeZero`                                |
+| `result`   | `uint64`      | ```PanicReason.TransferAmountCannotBeZero```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
@@ -2380,7 +2380,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + 64 > VM_MAX_RAM`
@@ -2390,7 +2390,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rC + 32 > VM_MAX_RAM`
@@ -2400,7 +2400,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rC >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rC >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, 64]` does not pass [ownership check](./main.md#ownership)
@@ -2430,7 +2430,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + $rC > VM_MAX_RAM`
@@ -2440,7 +2440,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rB >> 8 | rC >> 14`                       |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| rC >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
@@ -2451,7 +2451,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess | rC >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rC >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### S256: SHA-2-256
@@ -2475,7 +2475,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rA >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rA >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$rB + $rC > VM_MAX_RAM`
@@ -2485,7 +2485,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MemoryOverflow | rB >> 8 | rC >> 14`                       |
+| `result`   | `uint64`      | ```PanicReason.MemoryOverflow \| rB >> 8 \| rC >> 14```                 |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
@@ -2496,7 +2496,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.MaxMemoryAccess | rC >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.MaxMemoryAccess \| rC >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ## Transaction Access Opcodes
@@ -2523,7 +2523,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InputNotFound | rB >> 8`                                   |
+| `result`   | `uint64`      | ```PanicReason.InputNotFound \| rB >> 8```                              |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### XIS: Transaction input start
@@ -2546,7 +2546,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.InputNotFound | rB >> 8`                                   |
+| `result`   | `uint64`      | ```PanicReason.InputNotFound \| rB >> 8```                              |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### XOL: Transaction input length
@@ -2569,7 +2569,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.OutputNotFound | rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.OutputNotFound \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### XOS: Transaction output start
@@ -2592,7 +2592,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.OutputNotFound | rB >> 8`                                  |
+| `result`   | `uint64`      | ```PanicReason.OutputNotFound \| rB >> 8```                             |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 ### XWL: Transaction witness length
@@ -2615,7 +2615,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.WitnessNotFound | rB >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.WitnessNotFound \| rB >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Note that the returned length includes the [_entire_ witness](../protocol/tx_format.md), not just of the witness's `data` field.
@@ -2640,7 +2640,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.WitnessNotFound | rB >> 8`                                 |
+| `result`   | `uint64`      | ```PanicReason.WitnessNotFound \| rB >> 8```                            |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Note that the returned memory address includes the [_entire_ witness](../protocol/tx_format.md), not just of the witness's `data` field.
@@ -2687,7 +2687,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext                                    |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Set `$rA` to `true` if parent is an external context, `false` otherwise.
@@ -2703,7 +2703,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedInternalContext                                    |
+| `result`   | `uint64`      | ```PanicReason.ExpectedInternalContext```                               |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 - `$fp->$fp == 0` (if parent context is external)
@@ -2713,7 +2713,7 @@ In a script transaction, append an additional receipt to the list of receipts, m
 | name       | type          | description                                                             |
 |------------|---------------|-------------------------------------------------------------------------|
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`                                              |
-| `result`   | `uint64`      | `PanicReason.ExpectedParentInternalContext                              |
+| `result`   | `uint64`      | ```PanicReason.ExpectedParentInternalContext```                         |
 | `gas_used` | `uint64`      | Gas consumed by the script.                                             |
 
 Set `$rA` to `$fp->$fp` (i.e. `$rA` will point to the previous call frame's contract ID).


### PR DESCRIPTION
The panic reasons added in #227 weren't rendering properly in the tables. Should fix that.