### PR TITLE
Docs: Update BMST specs to include leaf fee within leaf digest

### DIFF
--- a/specs/protocol/cryptographic_primitives.md
+++ b/specs/protocol/cryptographic_primitives.md
@@ -22,27 +22,6 @@ A specification for the Binary Merkle Tree is [here](https://github.com/celestia
 
 The Binary Merkle Sum Tree is an extension of the tree defined in [RFC-6962](https://tools.ietf.org/html/rfc6962).
 
-Nodes contain four fields:
-
-| name        | type   | description                                   |
-|-------------|--------|-----------------------------------------------|
-| `fee`       | uint64 | Node fee                                      |
-| `digest`    | Hash   | Node value                                    |
-| `left_key`  | Hash   | Value of the left child (for internal nodes)  |
-| `right_key` | Hash   | Value of the right child (for internal nodes) |
-
-For leaf node `node` with fee `fee` and data `data`:
-```
-node.digest = hash(0x00 ++ fee ++ data)
-```
-
-For internal node `node` with left child `left` and right child `right`:
-```
-node.digest = hash(0x01 ++ left.fee ++ left.digest ++ right.fee ++ right.digest)
-```
-
-#### Root Pairs
-
 The root pair `(fee, digest)` of an empty tree is:
 
 ```
@@ -58,8 +37,6 @@ The root pair of a tree with one leaf:
 The root pair of a tree with two or more leaves is defined recursively:
 
 ```
-left = get(node.left_key)
-right = get(node.right_key)
 (left.fee + right.fee, hash(0x01 ++ left.fee ++ left.digest ++ right.fee ++ right.digest))
 ```
 


### PR DESCRIPTION
After some [discussion](https://github.com/FuelLabs/fuel-merkle/pull/44#pullrequestreview-823288392) on the `fuel-merkle` PR, we have decided to update the specification for BMST to include the leaf fee in the leaf digest calculation. 

Currently, the specification states that leaf hashes are calculated for data `data` as:
```
node.digest = hash(0x00 ++ data)
```

This current definition does not include the fee; the amended specification now states that leaf hashes are to be calculated thusly for fee `fee` and data `data`:
```
node.digest = hash(0x00 ++ fee ++ data)
```