### PR TITLE
add byte pricing independent of gas price

### DIFF
--- a/specs/chains/ethereum/compressed_tx_format.md
+++ b/specs/chains/ethereum/compressed_tx_format.md
@@ -32,6 +32,7 @@ This document specifies the _compressed_ transaction format, which is posted to 
 |--------------------|-------------------------|------------------------------------------|
 | `gasPrice`         | `uint64`                | Gas price for transaction.               |
 | `gasLimit`         | `uint64`                | Gas limit for transaction.               |
+| `bytePrice`        | `uint64`                | Price per transaction byte.              |
 | `maturity`         | `uint32`                | Block until which tx cannot be included. |
 | `scriptLength`     | `uint16`                | Script length, in instructions.          |
 | `scriptDataLength` | `uint16`                | Length of script input data, in bytes.   |
@@ -48,8 +49,7 @@ This document specifies the _compressed_ transaction format, which is posted to 
 
 | name                   | type                          | description                                   |
 |------------------------|-------------------------------|-----------------------------------------------|
-| `gasPrice`             | `uint64`                      | Gas price for transaction.                    |
-| `gasLimit`             | `uint64`                      | Gas limit for transaction.                    |
+| `bytePrice`            | `uint64`                      | Price per transaction byte.                   |
 | `maturity`             | `uint32`                      | Block until which tx cannot be included.      |
 | `bytecodeLength`       | `uint16`                      | Contract bytecode length, in instructions.    |
 | `bytecodeWitnessIndex` | `uint8`                       | Witness index of contract bytecode to create. |

--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -89,9 +89,9 @@ enum  ReceiptType : uint8 {
 
 | name               | type                    | description                              |
 |--------------------|-------------------------|------------------------------------------|
-| `bytePrice`        | `uint64`                | Price per transaction byte.              |
 | `gasPrice`         | `uint64`                | Gas price for transaction.               |
 | `gasLimit`         | `uint64`                | Gas limit for transaction.               |
+| `bytePrice`        | `uint64`                | Price per transaction byte.              |
 | `maturity`         | `uint32`                | Block until which tx cannot be included. |
 | `scriptLength`     | `uint16`                | Script length, in instructions.          |
 | `scriptDataLength` | `uint16`                | Length of script input data, in bytes.   |

--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -24,7 +24,6 @@
 
 | name                        | type     | value | description                                   |
 |-----------------------------|----------|-------|-----------------------------------------------|
-| `GAS_PER_BYTE`              | `uint64` |       | Gas charged per byte of the transaction.      |
 | `MAX_GAS_PER_TX`            | `uint64` |       | Maximum gas per transaction.                  |
 | `MAX_INPUTS`                | `uint64` | `8`   | Maximum number of inputs.                     |
 | `MAX_OUTPUTS`               | `uint64` | `8`   | Maximum number of outputs.                    |
@@ -90,6 +89,7 @@ enum  ReceiptType : uint8 {
 
 | name               | type                    | description                              |
 |--------------------|-------------------------|------------------------------------------|
+| `bytePrice`        | `uint64`                | Price per transaction byte.              |
 | `gasPrice`         | `uint64`                | Gas price for transaction.               |
 | `gasLimit`         | `uint64`                | Gas limit for transaction.               |
 | `maturity`         | `uint32`                | Block until which tx cannot be included. |
@@ -123,8 +123,7 @@ The receipts root `receiptsRoot` is the root of the [binary Merkle tree](./crypt
 
 | name                   | type                    | description                                   |
 |------------------------|-------------------------|-----------------------------------------------|
-| `gasPrice`             | `uint64`                | Gas price for transaction.                    |
-| `gasLimit`             | `uint64`                | Gas limit for transaction.                    |
+| `bytePrice`            | `uint64`                | Price per transaction byte.                   |
 | `maturity`             | `uint32`                | Block until which tx cannot be included.      |
 | `bytecodeLength`       | `uint16`                | Contract bytecode length, in instructions.    |
 | `bytecodeWitnessIndex` | `uint8`                 | Witness index of contract bytecode to create. |

--- a/specs/protocol/tx_validity.md
+++ b/specs/protocol/tx_validity.md
@@ -106,6 +106,7 @@ def unavailable_balance(tx, col) -> int:
     """
     sentBalance = sum_outputs(tx, col)
     gasBalance = gasPrice * gasLimit
+    # Size excludes witness data as it is malleable (even by third parties!)
     bytesBalance = size(tx) * bytePrice
     # Only native coin can be used to pay for gas
     if col != 0:
@@ -171,7 +172,7 @@ Given transaction `tx`, state `state`, and contract set `contracts`, the followi
 If change outputs are present, they must have:
 
 1. if the transaction does not revert; an `amount` of `unspentBalance + unspentGas * tx.gasPrice` if their asset ID is `0`, or an `amount` of the unspent free balance for that asset ID after VM execution is complete, or
-1. if the transaction reverts; an `amount` of the initial free balance minus spent gas times `tx.gasPrice` if their asset ID is `0`, or an `amount` of the initial free balance for that asset ID.
+1. if the transaction reverts; an `amount` of the initial free balance plus `unspentGas * tx.gasPrice` if their asset ID is `0`, or an `amount` of the initial free balance for that asset ID.
 
 ### State Changes
 

--- a/specs/protocol/tx_validity.md
+++ b/specs/protocol/tx_validity.md
@@ -106,7 +106,7 @@ def unavailable_balance(tx, col) -> int:
     """
     sentBalance = sum_outputs(tx, col)
     gasBalance = gasPrice * gasLimit
-    bytesBalance = size(tx) * GAS_PER_BYTE * gasPrice
+    bytesBalance = size(tx) * bytePrice
     # Only native coin can be used to pay for gas
     if col != 0:
         return sentBalance


### PR DESCRIPTION
closes #262

Add a separate bytePrice field to transaction specs, which allows script execution to be priced separately of bytes.

Open question: Should gas be renamed to something more specific like scriptGas or scriptPrice?