### PR TITLE
Add rule to verify predicate hash

### DIFF
--- a/specs/protocol/identifiers.md
+++ b/specs/protocol/identifiers.md
@@ -15,7 +15,7 @@ The _transaction ID_ (also called _transaction hash_) of a transaction is comput
 
 ## Contract ID
 
-For a transaction of type `TransactionType.Create`, `tx`, the contract ID is `sha256(0x4655454C ++ tx.data.salt ++ root(tx.data.witnesses[bytecodeWitnessIndex].data))`, where `root` is the Merkle root of [the binary Merkle tree](./cryptographic_primitives.md#binary-merkle-tree) with each leaf being an 8-byte word of bytecode. If the bytecode is not a multiple of 8 bytes (i.e. if there are an odd number of instructions), the last opcode is padded with 4-byte zero.
+For a transaction of type `TransactionType.Create`, `tx`, the contract ID is `sha256(0x4655454C ++ tx.data.salt ++ root(tx.data.witnesses[bytecodeWitnessIndex].data))`, where `root` is the Merkle root of [the binary Merkle tree](./cryptographic_primitives.md#binary-merkle-tree) with each leaf being an 8-byte word of two instructions. If the bytecode is not a multiple of 8 bytes (i.e. if there are an odd number of instructions), the last instruction is padded with 4-byte zero.
 
 ## UTXO ID
 

--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -196,6 +196,7 @@ Transaction is invalid if:
 - `witnessIndex >= tx.witnessesCount`
 - `predicateLength > MAX_PREDICATE_LENGTH`
 - `predicateDataLength > MAX_PREDICATE_DATA_LENGTH`
+- If `predicateLength > 0`; the computed predicate root (see below) is not equal `owner`
 
 If `h` is the block height the UTXO being spent was created, transaction is invalid if `blockheight() < h + maturity`.
 
@@ -204,6 +205,8 @@ Note: when signing a transaction, `txoPointer` is set to zero.
 Note: when verifying a predicate, `txoPointer` is initialized to zero.
 
 Note: when executing a script, `txoPointer` is initialized to zero.
+
+The predicate root is computed identically to the contract ID, [here](./identifiers.md#contract-id).
 
 ### InputContract
 


### PR DESCRIPTION
Fixes #264

For now, compute the predicate root computed the same way as the contract ID. Eventually it will be domain separated differently with #201.