### PR TITLE
Update predicate root definition in specs

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -216,7 +216,7 @@ Note: when verifying a predicate, `txPointer` is initialized to zero.
 
 Note: when executing a script, `txPointer` is initialized to zero.
 
-The predicate root is computed identically to the contract ID, [here](./identifiers.md#contract-id).
+The predicate root is computed identically to the contract root, used to compute the contract ID, [here](./identifiers.md#contract-id).
 
 ### InputContract
 


### PR DESCRIPTION
Prior to this commit, the specs suggested the predicated root should use
the same computation of the contract id; when in fact it should be the
same computation of the contract root.