### PR TITLE
Add gas price factor.

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -22,18 +22,19 @@
 
 ## Constants
 
-| name                        | type     | value | description                                   |
-|-----------------------------|----------|-------|-----------------------------------------------|
-| `GAS_PER_BYTE`              | `uint64` |       | Gas charged per byte of the transaction.      |
-| `MAX_GAS_PER_TX`            | `uint64` |       | Maximum gas per transaction.                  |
-| `MAX_INPUTS`                | `uint64` | `8`   | Maximum number of inputs.                     |
-| `MAX_OUTPUTS`               | `uint64` | `8`   | Maximum number of outputs.                    |
-| `MAX_PREDICATE_LENGTH`      | `uint64` |       | Maximum length of predicate, in instructions. |
-| `MAX_PREDICATE_DATA_LENGTH` | `uint64` |       | Maximum length of predicate data, in bytes.   |
-| `MAX_SCRIPT_LENGTH`         | `uint64` |       | Maximum length of script, in instructions.    |
-| `MAX_SCRIPT_DATA_LENGTH`    | `uint64` |       | Maximum length of script data, in bytes.      |
-| `MAX_STORAGE_SLOTS`         | `uint16` | `255` | Maximum number of initial storage slots.      |
-| `MAX_WITNESSES`             | `uint64` | `16`  | Maximum number of witnesses.                  |
+| name                        | type     | value           | description                                   |
+|-----------------------------|----------|-----------------|-----------------------------------------------|
+| `GAS_PER_BYTE`              | `uint64` |                 | Gas charged per byte of the transaction.      |
+| `GAS_PRICE_FACTOR`          | `uint64` | `1,000,000,000` | Unit factor for gas price.                    |
+| `MAX_GAS_PER_TX`            | `uint64` |                 | Maximum gas per transaction.                  |
+| `MAX_INPUTS`                | `uint64` | `8`             | Maximum number of inputs.                     |
+| `MAX_OUTPUTS`               | `uint64` | `8`             | Maximum number of outputs.                    |
+| `MAX_PREDICATE_LENGTH`      | `uint64` |                 | Maximum length of predicate, in instructions. |
+| `MAX_PREDICATE_DATA_LENGTH` | `uint64` |                 | Maximum length of predicate data, in bytes.   |
+| `MAX_SCRIPT_LENGTH`         | `uint64` |                 | Maximum length of script, in instructions.    |
+| `MAX_SCRIPT_DATA_LENGTH`    | `uint64` |                 | Maximum length of script data, in bytes.      |
+| `MAX_STORAGE_SLOTS`         | `uint16` | `255`           | Maximum number of initial storage slots.      |
+| `MAX_WITNESSES`             | `uint64` | `16`            | Maximum number of witnesses.                  |
 
 ## TransactionType
 

--- a/specs/protocol/tx_validity.md
+++ b/specs/protocol/tx_validity.md
@@ -100,9 +100,9 @@ def unavailable_balance(tx, col) -> int:
     monotonic and the cost of Ethereum calldata more than makes up for this
     """
     sentBalance = sum_outputs(tx, col)
-    gasBalance = gasPrice * gasLimit
+    gasBalance = ceiling((gasPrice * gasLimit) / GAS_PRICE_FACTOR)
     # Size excludes witness data as it is malleable (even by third parties!)
-    bytesBalance = size(tx) * gasPrice * GAS_PER_BYTE
+    bytesBalance = ceiling((size(tx) * gasPrice * GAS_PER_BYTE) / GAS_PRICE_FACTOR)
     # Only native coin can be used to pay for gas
     if col != 0:
         return sentBalance
@@ -154,7 +154,7 @@ Once the free balances are computed, the [script is executed](../vm/main.md#scri
 1. The unspent free balance `unspentBalance` for each asset ID.
 1. The unspent gas `unspentGas` from the `$ggas` register.
 
-The fees incurred for a transaction are `(tx.gasLimit - unspentGas) * tx.gasPrice`.
+The fees incurred for a transaction are `ceiling(((tx.gasLimit - unspentGas) * tx.gasPrice) / GAS_PRICE_FACTOR)`.
 
 If the transaction as included in a block does not match this final transaction, the block is invalid.
 
@@ -168,7 +168,7 @@ Given transaction `tx`, state `state`, and contract set `contracts`, the followi
 
 If change outputs are present, they must have:
 
-1. if the transaction does not revert; an `amount` of `unspentBalance + unspentGas * tx.gasPrice` if their asset ID is `0`, or an `amount` of the unspent free balance for that asset ID after VM execution is complete, or
+1. if the transaction does not revert; an `amount` of `unspentBalance + floor((unspentGas * tx.gasPrice) / GAS_PRICE_FACTOR)` if their asset ID is `0`, or an `amount` of the unspent free balance for that asset ID after VM execution is complete, or
 1. if the transaction reverts; an `amount` of the initial free balance plus `unspentGas * tx.gasPrice` if their asset ID is `0`, or an `amount` of the initial free balance for that asset ID.
 
 ### State Changes


### PR DESCRIPTION
Fixes #342

Adds a new consensus constant, `GAS_PRICE_FACTOR` (suggested to be set to 1 billion), that allows gas price to be provided with a precision of `1/GAS_PRICE_FACTOR` of the base asset's unit.

Gas used is rounded up to the nearest unit, and gas refunded in rounded down. **Note** gas and byte costs are accounted for separately. Therefore, the minimum non-zero used balance is 2 coins: one for gas and one for bytes.

E.g. if the base asset is ETH at 9 decimals, then its units are gwei. This change allows gas prices to be specified in wei. If a tx costs less than 1 gwei of `gas price * gas limit / GAS_PRICE_FACTOR`, then it rounds up to costing 1 gwei.

Some considerations around parameter choice: a script that uses 10M gas can have a gas price of ~100B before you have to start worrying about overflow. Assuming ETH as the base asset:

1. With a factor of 1B, the maximum gas price is ~100 gwei. In the long run, this doesn't leave much room for a robust fee market.
2. With a factor of 1M, the maximum gas price is ~10,000 gwei. Lots of breathing room.
3. With a factor of 1,000, the gas price is 0.001 gwei. This might not be cheap enough. Transactions may still cost on the order of cents even at the lowest gas price.

I'm inclined towards a factor of 1M from the above, but would like to hear what @Voxelot @vlopes11 and @rakita think.

Implementation:

- [ ] fuel-tx: https://github.com/FuelLabs/fuel-tx/pull/141
- [ ] fuel-vm: 