### PR TITLE
Format tables and toc

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -171,9 +171,9 @@ enum  InputType : uint8 {
 
 ## Input
 
-| name   | type                                                              | description    |
-|--------|-------------------------------------------------------------------|----------------|
-| `type` | [InputType](#inputtype)                                           | Type of input. |
+| name   | type                                                                                              | description    |
+|--------|---------------------------------------------------------------------------------------------------|----------------|
+| `type` | [InputType](#inputtype)                                                                           | Type of input. |
 | `data` | One of [InputCoin](#inputcoin), [InputContract](#inputcontract), or [InputMessage](#inputmessage) | Input data.    |
 
 Transaction is invalid if:
@@ -237,21 +237,21 @@ Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, and `stateR
 
 ### InputMessage
 
-| name                  | type        | description                                                            |
-|-----------------------|-------------|------------------------------------------------------------------------|
-| `messageID`           | `byte[32]`  | The messageID as described [here](./identifiers.md#input-message-id).  |
-| `sender`              | `byte[32]`  | The address of the message sender.                                     |
-| `recipient`           | `byte[32]`  | The address of the message recipient.                                  |
-| `amount`              | `uint64`    | Amount of base asset coins sent with message.                          |
-| `nonce`               | `uint64`    | The message nonce.                                                     |
-| `owner`               | `byte[32]`  | Owning address or predicate root.                                      |
-| `witnessIndex`        | `uint8`     | Index of witness that authorizes spending the coin.                    |
-| `dataLength`          | `uint16`    | Length of message data, in bytes.                                      |
-| `predicateLength`     | `uint16`    | Length of predicate, in instructions.                                  |
-| `predicateDataLength` | `uint16`    | Length of predicate input data, in bytes.                              |
-| `data`                | `byte[]`    | The message data.                                                      |
-| `predicate`           | `byte[]`    | Predicate bytecode.                                                    |
-| `predicateData`       | `byte[]`    | Predicate input data (parameters).                                     |
+| name                  | type       | description                                                           |
+|-----------------------|------------|-----------------------------------------------------------------------|
+| `messageID`           | `byte[32]` | The messageID as described [here](./identifiers.md#input-message-id). |
+| `sender`              | `byte[32]` | The address of the message sender.                                    |
+| `recipient`           | `byte[32]` | The address of the message recipient.                                 |
+| `amount`              | `uint64`   | Amount of base asset coins sent with message.                         |
+| `nonce`               | `uint64`   | The message nonce.                                                    |
+| `owner`               | `byte[32]` | Owning address or predicate root.                                     |
+| `witnessIndex`        | `uint8`    | Index of witness that authorizes spending the coin.                   |
+| `dataLength`          | `uint16`   | Length of message data, in bytes.                                     |
+| `predicateLength`     | `uint16`   | Length of predicate, in instructions.                                 |
+| `predicateDataLength` | `uint16`   | Length of predicate input data, in bytes.                             |
+| `data`                | `byte[]`   | The message data.                                                     |
+| `predicate`           | `byte[]`   | Predicate bytecode.                                                   |
+| `predicateData`       | `byte[]`   | Predicate input data (parameters).                                    |
 
 Transaction is invalid if:
 
@@ -278,9 +278,9 @@ enum  OutputType : uint8 {
 
 ## Output
 
-| name   | type                                                                                                                                                                                                                             | description     |
-|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
-| `type` | [OutputType](#outputtype)                                                                                                                                                                                                         | Type of output. |
+| name   | type                                                                                                                                                                                                                       | description     |
+|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| `type` | [OutputType](#outputtype)                                                                                                                                                                                                  | Type of output. |
 | `data` | One of [OutputCoin](#outputcoin), [OutputContract](#outputcontract), [OutputMessage](#outputmessage) [OutputChange](#outputchange), [OutputVariable](#outputvariable), or [OutputContractCreated](#outputcontractcreated). | Output data.    |
 
 Transaction is invalid if:
@@ -320,10 +320,10 @@ The state root `stateRoot` is the root of the [SMT](./cryptographic_primitives.m
 
 ### OutputMessage
 
-| name                  | type        | description                                                             |
-|-----------------------|-------------|-------------------------------------------------------------------------|
-| `recipient`           | `byte[32]`  | The address of the message recipient.                                   |
-| `amount`              | `uint64`    | Amount of base asset coins sent with message.                           |
+| name        | type       | description                                   |
+|-------------|------------|-----------------------------------------------|
+| `recipient` | `byte[32]` | The address of the message recipient.         |
+| `amount`    | `uint64`   | Amount of base asset coins sent with message. |
 
 Note: when signing a transaction `recipient` and `amount` are set to zero.
 

--- a/specs/vm/instruction_set.md
+++ b/specs/vm/instruction_set.md
@@ -71,7 +71,7 @@
   - [MINT: Mint new coins](#mint-mint-new-coins)
   - [RETD: Return from context with data](#retd-return-from-context-with-data)
   - [RVRT: Revert](#rvrt-revert)
-  - [SMO: Send Message to output](#smo-send-message-to-output)
+  - [SMO: Send message to output](#smo-send-message-to-output)
   - [SRW: State read word](#srw-state-read-word)
   - [SRWQ: State read 32 bytes](#srwq-state-read-32-bytes)
   - [SWW: State write word](#sww-state-write-word)
@@ -1420,13 +1420,13 @@ Cease VM execution and revert script effects. After a revert:
 
 ### SMO: Send message to output
 
-|             |                                                                                     |
-|-------------|-------------------------------------------------------------------------------------|
+|             |                                                                                                                           |
+|-------------|---------------------------------------------------------------------------------------------------------------------------|
 | Description | Send a message to recipient address `MEM[$rA, 32]` with call abi `MEM[$rA + 32, $rB]` and `$rD` coins, with output `$rC`. |
-| Operation   | ```outputmessage(MEM[$fp, 32], MEM[$rA, 32], MEM[$rA + 32, $rB], $rD, $rC);```      |
-| Syntax      | `smo $rA, $rB, $rC, $rD`                                                            |
-| Encoding    | `0x00 rA rB rC rD`                                                                  |
-| Notes       |                                                                                     |
+| Operation   | ```outputmessage(MEM[$fp, 32], MEM[$rA, 32], MEM[$rA + 32, $rB], $rD, $rC);```                                            |
+| Syntax      | `smo $rA, $rB, $rC, $rD`                                                                                                  |
+| Encoding    | `0x00 rA rB rC rD`                                                                                                        |
+| Notes       |                                                                                                                           |
 
 Given helper `balanceOfStart(asset_id: byte[32]) -> uint32` which returns the memory address of the remaining free balance of `asset_id`, or panics if `asset_id` has no free balance remaining.
 
@@ -1445,16 +1445,16 @@ Panic if:
 
 Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
 
-| name         | type          | description                                                                              |
-|--------------|---------------|------------------------------------------------------------------------------------------|
-| `type`       | `ReceiptType` | `ReceiptType.MessageOut`                                                                 |
-| `messageID`  | `byte[32]`    | The messageID as described [here](../protocol/identifiers.md#output-message-id).         |
-| `sender`     | `byte[32]`    | The address of the message sender: `MEM[$fp, 32]`.                                       |
-| `recipient`  | `byte[32]`    | The address of the message recipient: `MEM[$rA, 32]`.                                    |
-| `amount`     | `uint64`      | Amount of base asset coins sent with message: `$rD`.                                     |
-| `nonce`      | `byte[32]`    | The message nonce as described [here](../protocol/identifiers.md#output-message-nonce).  |
-| `len`        | `uint16`      | Length of message data, in bytes: `$rB`.                                                 |
-| `digest`     | `byte[32]`    | [Hash](#s256-sha-2-256) of `MEM[$rA + 32, $rB]`.                                         |
+| name        | type          | description                                                                             |
+|-------------|---------------|-----------------------------------------------------------------------------------------|
+| `type`      | `ReceiptType` | `ReceiptType.MessageOut`                                                                |
+| `messageID` | `byte[32]`    | The messageID as described [here](../protocol/identifiers.md#output-message-id).        |
+| `sender`    | `byte[32]`    | The address of the message sender: `MEM[$fp, 32]`.                                      |
+| `recipient` | `byte[32]`    | The address of the message recipient: `MEM[$rA, 32]`.                                   |
+| `amount`    | `uint64`      | Amount of base asset coins sent with message: `$rD`.                                    |
+| `nonce`     | `byte[32]`    | The message nonce as described [here](../protocol/identifiers.md#output-message-nonce). |
+| `len`       | `uint16`      | Length of message data, in bytes: `$rB`.                                                |
+| `digest`    | `byte[32]`    | [Hash](#s256-sha-2-256) of `MEM[$rA + 32, $rB]`.                                        |
 
 In an external context, decrease `MEM[balanceOfStart(0), 8]` by `$rD`. In an internal context, decrease asset ID 0 balance of output with contract ID `MEM[$fp, 32]` by `$rD`. Then set:
 

--- a/specs/vm/main.md
+++ b/specs/vm/main.md
@@ -18,12 +18,12 @@ This document provides the specification for the Fuel Virtual Machine (FuelVM). 
 
 ## Parameters
 
-| name                       | type     | value   | note                                        |
-|----------------------------|----------|---------|---------------------------------------------|
-| `CONTRACT_MAX_SIZE`        | `uint64` |         | Maximum contract size, in bytes.            |
-| `MEM_MAX_ACCESS_SIZE`      | `uint64` |         | Maximum memory access size, in bytes.       |
-| `VM_MAX_RAM`               | `uint64` | `2**26` | 64 MiB.                                     |
-| `MESSAGE_MAX_DATA_SIZE`    | `uint16` |         | Maximum size of message data, in bytes.     |
+| name                    | type     | value   | note                                    |
+|-------------------------|----------|---------|-----------------------------------------|
+| `CONTRACT_MAX_SIZE`     | `uint64` |         | Maximum contract size, in bytes.        |
+| `MEM_MAX_ACCESS_SIZE`   | `uint64` |         | Maximum memory access size, in bytes.   |
+| `VM_MAX_RAM`            | `uint64` | `2**26` | 64 MiB.                                 |
+| `MESSAGE_MAX_DATA_SIZE` | `uint16` |         | Maximum size of message data, in bytes. |
 
 ## Semantics
 


### PR DESCRIPTION
Following on #318, format.

Markdown table prettifier and markdownlint as per https://github.com/FuelLabs/fuel-specs/tree/cdff152668088c6a9ea29a5fb8b257c07b901934#contributing