### PR TITLE
fix eager rounding, including missing byte costs in resultant fee

### DIFF
--- a/specs/protocol/tx_validity.md
+++ b/specs/protocol/tx_validity.md
@@ -107,13 +107,15 @@ def unavailable_balance(tx, col) -> int:
     monotonic and the cost of bytes should approximately makes up for this.
     """
     sentBalance = sum_outputs(tx, col)
-    gasBalance = ceiling((gasPrice * gasLimit) / GAS_PRICE_FACTOR)
+    gasBalance = gasPrice * gasLimit / GAS_PRICE_FACTOR
     # Size excludes witness data as it is malleable (even by third parties!)
-    bytesBalance = ceiling((size(tx) * gasPrice * GAS_PER_BYTE) / GAS_PRICE_FACTOR)
+    bytesBalance = size(tx) * GAS_PER_BYTE * gasPrice / GAS_PRICE_FACTOR
+    # Total fee balance
+    feeBalance = ceiling(gasBalance + bytesBalance)
     # Only base asset can be used to pay for gas
     if col != 0:
         return sentBalance
-    return sentBalance + gasBalance + bytesBalance
+    return sentBalance + feeBalance
 
 return available_balance(tx, col) >= unavailable_balance(tx, col)
 ```
@@ -161,7 +163,7 @@ Once the free balances are computed, the [script is executed](../vm/main.md#scri
 1. The unspent free balance `unspentBalance` for each asset ID.
 1. The unspent gas `unspentGas` from the `$ggas` register.
 
-The fees incurred for a transaction are `ceiling(((tx.gasLimit - unspentGas) * tx.gasPrice) / GAS_PRICE_FACTOR)`.
+The fees incurred for a transaction are `ceiling(((size(tx) * GAS_PER_BYTE) + (tx.gasLimit - unspentGas)) * tx.gasPrice / GAS_PRICE_FACTOR)`.
 
 If the transaction as included in a block does not match this final transaction, the block is invalid.
 


### PR DESCRIPTION
> gasBalance = ceiling((gasPrice * gasLimit) / GAS_PRICE_FACTOR)
> bytesBalance = ceiling((size(tx) * gasPrice * GAS_PER_BYTE) / GAS_PRICE_FACTOR)
> return sentBalance + gasBalance + bytesBalance

- When calculating unavailableBalance, we shouldn't round gas separately from bytes as the minimum unavailableBalance will be `2` instead of `1`, even though we would only charge an amount of `1`. @luizstacio raised this to my attention.

> The fees incurred for a transaction are `ceiling(((tx.gasLimit - unspentGas) * tx.gasPrice) / GAS_PRICE_FACTOR)`.
- Bytes were not included in the final post-execution fee calculation. If `tx.gasLimit` and `tx.gasPrice` are intended to be the sole determining factors in how much a tx costs, we'd need to make the following changes instead:
  - exclude byte calculations from the unavailableBalance
  - initialize G_GAS and C_GAS with `tx.gasLimit - (size(tx) * GAS_PER_BYTE)` instead of `tx.gasLimit`
