### PR TITLE
Fix the JSON ABI of the complex example

### DIFF
--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -448,7 +448,20 @@ its JSON representation would look like:
                 ]
               }
             ],
-            "typeArguments": null
+            "typeArguments": [
+              {
+                "name": "T",
+                "type": "u64",
+                "components": null,
+                "typeArguments": null
+              },
+              {
+                "name": "U",
+                "type": "bool",
+                "components": null,
+                "typeArguments": null
+              }
+            ]
           }
         ],
         "typeArguments": null
@@ -483,7 +496,7 @@ its JSON representation would look like:
             "typeArguments": null
           }
         ],
-        "typeArguments": null 
+        "typeArguments": null
       }
     ],
     "outputs": [


### PR DESCRIPTION
The type arguments for `MyStruct` in `"[struct MyStruct; 4]"` were missing.

Corresponding change in the compiler: https://github.com/FuelLabs/sway/pull/2303