### PR TITLE
Set contract input values in validity rules instead of tx format

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -244,7 +244,7 @@ Note: when signing a transaction, `txID`, `outputIndex`, `balanceRoot`, `stateRo
 
 Note: when verifying a predicate, `txID`, `outputIndex`, `balanceRoot`, `stateRoot`, and `txPointer` are initialized to zero.
 
-Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, `stateRoot` and `txPointer`  are initialized to the transaction ID, output index, amount, state root and txPointer of the contract with ID `contractID`.
+Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, `stateRoot` and `txPointer` are initialized to the transaction ID, output index, amount, state root and txPointer of the contract with ID `contractID`.
 
 ### InputMessage
 

--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -244,7 +244,7 @@ Note: when signing a transaction, `txID`, `outputIndex`, `balanceRoot`, `stateRo
 
 Note: when verifying a predicate, `txID`, `outputIndex`, `balanceRoot`, `stateRoot`, and `txPointer` are initialized to zero.
 
-Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, `stateRoot` and `txPointer` are initialized to the transaction ID, output index, amount, state root and txPointer of the contract with ID `contractID`.
+Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, `stateRoot` and `txPointer` are initialized to zero.
 
 ### InputMessage
 

--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -221,7 +221,7 @@ Note: when signing a transaction, `txPointer` is set to zero.
 
 Note: when verifying a predicate, `txPointer` is initialized to zero.
 
-Note: when executing a script, `txPointer` is initialized to zero.
+Note: when executing a script, `txPointer` is initialized to the transaction output being spent.
 
 The predicate root is computed identically to the contract root, used to compute the contract ID, [here](./identifiers.md#contract-id).
 
@@ -244,7 +244,7 @@ Note: when signing a transaction, `txID`, `outputIndex`, `balanceRoot`, `stateRo
 
 Note: when verifying a predicate, `txID`, `outputIndex`, `balanceRoot`, `stateRoot`, and `txPointer` are initialized to zero.
 
-Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, and `stateRoot` are initialized to the transaction ID, output index, amount, and state root of the contract with ID `contractID`, and `txPointer` is initialized to zero.
+Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, `stateRoot` and `txPointer`  are initialized to the transaction ID, output index, amount, state root and txPointer of the contract with ID `contractID`.
 
 ### InputMessage
 

--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -221,7 +221,7 @@ Note: when signing a transaction, `txPointer` is set to zero.
 
 Note: when verifying a predicate, `txPointer` is initialized to zero.
 
-Note: when executing a script, `txPointer` is initialized to the transaction output being spent.
+Note: when executing a script, `txPointer` is initialized to zero.
 
 The predicate root is computed identically to the contract root, used to compute the contract ID, [here](./identifiers.md#contract-id).
 

--- a/specs/protocol/tx_validity.md
+++ b/specs/protocol/tx_validity.md
@@ -76,7 +76,7 @@ for input in tx.inputs:
 return True
 ```
 
-If this check passes, the UTXO ID `(txID, outputIndex)` fields of each contract input is set to the UTXO ID of the respective contract. The `txPointer` of each input is also set to the TX pointer of the UTXO with ID `utxoID`.
+If this check passes, the UTXO ID `(txID, outputIndex)`, `stateRoot`, and `balanceRoot` fields of each contract input are set to the current values of the respective contract. The `txPointer` of each input is also set to the TX pointer of the UTXO with ID `utxoID`.
 
 ### Sufficient Balance
 


### PR DESCRIPTION
We had somewhat conflicting definitions of when and how contract input values should be set between tx_format and tx_validity. This PR moves the description of how to set the contract inputs all to the validity rules.