### PR TITLE
Add timestamp instruction.

### DIFF
--- a/specs/vm/instruction_set.md
+++ b/specs/vm/instruction_set.md
@@ -74,7 +74,7 @@
   - [SRWQ: State read 32 bytes](#srwq-state-read-32-bytes)
   - [SWW: State write word](#sww-state-write-word)
   - [SWWQ: State write 32 bytes](#swwq-state-write-32-bytes)
-  - [TIME: Current timstamp](#time-current-timstamp)
+  - [TIME: Timstamp at height](#time-timstamp-at-height)
   - [TR: Transfer coins to contract](#tr-transfer-coins-to-contract)
   - [TRO: Transfer coins to output](#tro-transfer-coins-to-output)
 - [Cryptographic Instructions](#cryptographic-instructions)
@@ -1489,7 +1489,7 @@ Panic if:
 - `$rB + 32 > VM_MAX_RAM`
 - `$fp == 0` (in the script context)
 
-### TIME: Current timstamp
+### TIME: Timstamp at height
 
 |             |                                         |
 |-------------|-----------------------------------------|

--- a/specs/vm/instruction_set.md
+++ b/specs/vm/instruction_set.md
@@ -1491,19 +1491,20 @@ Panic if:
 
 ### TIME: Current timstamp
 
-|             |                                |
-|-------------|--------------------------------|
-| Description | Get current block's timestamp. |
-| Operation   | ```$rA = time();```            |
-| Syntax      | `time $rA`                     |
-| Encoding    | `0x00 rA - - -`                |
-| Notes       |                                |
+|             |                                         |
+|-------------|-----------------------------------------|
+| Description | Get timestamp of block at given height. |
+| Operation   | ```$rA = time($rB);```                  |
+| Syntax      | `time $rA, $rB`                         |
+| Encoding    | `0x00 rA rB - -`                        |
+| Notes       |                                         |
 
 Panic if:
 
 - `$rA` is a [reserved register](./main.md#semantics)
+- `$rB` is greater than the current block height.
 
-Gets the timestamp of the current block. Time is in [TAI64](https://cr.yp.to/libtai/tai64.html) format.
+Gets the timestamp of the block at height `$rB`. Time is in [TAI64](https://cr.yp.to/libtai/tai64.html) format.
 
 ### TR: Transfer coins to contract
 

--- a/specs/vm/instruction_set.md
+++ b/specs/vm/instruction_set.md
@@ -74,6 +74,7 @@
   - [SRWQ: State read 32 bytes](#srwq-state-read-32-bytes)
   - [SWW: State write word](#sww-state-write-word)
   - [SWWQ: State write 32 bytes](#swwq-state-write-32-bytes)
+  - [TIME: Current timstamp](#time-current-timstamp)
   - [TR: Transfer coins to contract](#tr-transfer-coins-to-contract)
   - [TRO: Transfer coins to output](#tro-transfer-coins-to-output)
 - [Cryptographic Instructions](#cryptographic-instructions)
@@ -1487,6 +1488,22 @@ Panic if:
 - `$rA + 32 > VM_MAX_RAM`
 - `$rB + 32 > VM_MAX_RAM`
 - `$fp == 0` (in the script context)
+
+### TIME: Current timstamp
+
+|             |                                |
+|-------------|--------------------------------|
+| Description | Get current block's timestamp. |
+| Operation   | ```$rA = time();```            |
+| Syntax      | `time $rA`                     |
+| Encoding    | `0x00 rA - - -`                |
+| Notes       |                                |
+
+Panic if:
+
+- `$rA` is a [reserved register](./main.md#semantics)
+
+Gets the timestamp of the current block. Time is in [TAI64](https://cr.yp.to/libtai/tai64.html) format.
 
 ### TR: Transfer coins to contract
 


### PR DESCRIPTION
Closes #220

Two considerations:

1. Do we want to get the timestamp of a given block, instead of the current block? Would require an addition instruction (block height) before using this if you wanted to get the time of the current block, but would open up the door to querying past block timestamps.
2. What time format do we want? I suggest TAI64 since it's 64-bit and there's a Rust crate for it.

Implementation:

- [x] fuel-asm: https://github.com/FuelLabs/fuel-asm/issues/88
- [ ] fuel-vm: https://github.com/FuelLabs/fuel-vm/issues/183