### PR TITLE
Removed owner from input messages

### DIFF
--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -767,11 +767,11 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 #### MessageOut receipt
 
 - `type`: `MessageOut`.
-- `messageID`: Hexadecimal string representation of the 256-bit (32-byte) message ID as described [here](../protocol/identifiers.md#output-message-id).
+- `messageID`: Hexadecimal string representation of the 256-bit (32-byte) message ID as described [here](../protocol/identifiers.md#message-id).
 - `sender`: Hexadecimal string representation of the 256-bit (32-byte) address of the message sender: `MEM[$fp, 32]`.
 - `recipient`: Hexadecimal string representation of the 256-bit (32-byte) address of the message recipient: `MEM[$rA, 32]`.
 - `amount`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$rD`.
-- `nonce`: Hexadecimal string representation of the 256-bit (32-byte) message nonce as described [here](../protocol/identifiers.md#output-message-nonce).
+- `nonce`: Hexadecimal string representation of the 256-bit (32-byte) message nonce as described [here](../protocol/identifiers.md#message-nonce).
 - `len`: Decimal string representation of a 16-bit unsigned integer; value of register `$rB`.
 - `digest`: Hexadecimal string representation of 256-bit (32-byte), hash of `MEM[$rA + 32, $rB]`.
 - `data`: Hexadecimal string representation of the value of the memory range `MEM[$rA + 32, $rB]`.

--- a/specs/protocol/identifiers.md
+++ b/specs/protocol/identifiers.md
@@ -4,9 +4,8 @@
 - [Contract ID](#contract-id)
 - [UTXO ID](#utxo-id)
   - [Coin ID](#coin-id)
-  - [Input Message ID](#input-message-id)
-  - [Output Message ID](#output-message-id)
-    - [Output Message Nonce](#output-message-nonce)
+  - [Message ID](#message-id)
+    - [Message Nonce](#message-nonce)
   - [Fee ID](#fee-id)
 
 This document defines how to compute unique identifiers.
@@ -25,34 +24,21 @@ For a transaction of type `TransactionType.Create`, `tx`, the contract ID is `sh
 
 Is represented as an _outpoint_: a pair of [transaction ID](#transaction-id) as `byte[32]` and output index as a `uint8`.
 
-### Input Message ID
+### Message ID
 
-The ID of an input message is computed as the [hash](./cryptographic_primitives.md#hashing) of:
-
-1. the sender address as `byte[32]`,
-1. recipient address as `byte[32]`,
-1. the message owner (either address or predicate root) as `byte[32]`,
-1. the message nonce as `uint64`,
-1. the amount being sent with the message as `uint64`,
-1. the message data as `byte[]`
-
-`hash(byte[32] ++ byte[32] ++ byte[32] ++ uint64 ++ uint64 ++ byte[])`. The address values are serialized as a byte array of length 32 left-padded with zeroes, and all other value types are serialized according to the standard [transaction serialization](./tx_format.md#transaction). Note that the message data length is not included since there is only one dynamically sized field and can be implicitly determined by the hash preimage size.
-
-### Output Message ID
-
-The ID of an output message is computed as the [hash](./cryptographic_primitives.md#hashing) of:
+The ID of a message is computed as the [hash](./cryptographic_primitives.md#hashing) of:
 
 1. the sender address as `byte[32]`,
-1. recipient address as `byte[32]`,
-1. the [OutputMessage nonce](#output-message-nonce) as `byte[32]`,
+1. the recipient address as `byte[32]`,
+1. the [Message nonce](#message-nonce) as `byte[32]`,
 1. the amount being sent with the message as `uint64`,
 1. the message data as `byte[]`
 
 `hash(byte[32] ++ byte[32] ++ byte[32] ++ uint64 ++ byte[])`. The address values are serialized as a byte array of length 32 left-padded with zeroes, and all other value types are serialized according to the standard [transaction serialization](./tx_format.md#transaction). Note that the message data length is not included since there is only one dynamically sized field and can be implicitly determined by the hash preimage size.
 
-#### Output Message Nonce
+#### Message Nonce
 
-The nonce value for `OutputMessage` is computed as the [hash](./cryptographic_primitives.md#hashing) of the [Transaction ID](#transaction-id) that the message is an output for and the index of the output as a `uint8`: `hash(byte[32] ++ uint8)`.
+The nonce value for `InputMessage` is determined by the sending system and is published at the time the message is sent. The nonce value for `OutputMessage` is computed as the [hash](./cryptographic_primitives.md#hashing) of the [Transaction ID](#transaction-id) that the message is an output for and the index of the output as a `uint8`: `hash(byte[32] ++ uint8)`.
 
 ### Fee ID
 

--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -67,7 +67,7 @@ Transaction is invalid if:
 - Any output is of type `OutputType.Change` for any asset ID not in the input set
 - More than one input of type `InputType.Coin` for any [Coin ID](./identifiers.md#coin-id) in the input set
 - More than one input of type `InputType.Contract` for any [Contract ID](./identifiers.md#contract-id) in the input set
-- More than one input of type `InputType.Message` for any [Input Message ID](./identifiers.md#input-message-id) in the input set
+- More than one input of type `InputType.Message` for any [Message ID](./identifiers.md#message-id) in the input set
 
 When serializing a transaction, fields are serialized as follows (with inner structs serialized recursively):
 
@@ -250,12 +250,11 @@ Note: when executing a script, `txID`, `outputIndex`, `balanceRoot`, and `stateR
 
 | name                  | type       | description                                                           |
 |-----------------------|------------|-----------------------------------------------------------------------|
-| `messageID`           | `byte[32]` | The messageID as described [here](./identifiers.md#input-message-id). |
+| `messageID`           | `byte[32]` | The messageID as described [here](./identifiers.md#message-id). |
 | `sender`              | `byte[32]` | The address of the message sender.                                    |
-| `recipient`           | `byte[32]` | The address of the message recipient.                                 |
+| `recipient`           | `byte[32]` | The address or predicate root of the message recipient.               |
 | `amount`              | `uint64`   | Amount of base asset coins sent with message.                         |
 | `nonce`               | `uint64`   | The message nonce.                                                    |
-| `owner`               | `byte[32]` | Owning address or predicate root.                                     |
 | `witnessIndex`        | `uint8`    | Index of witness that authorizes spending the coin.                   |
 | `dataLength`          | `uint16`   | Length of message data, in bytes.                                     |
 | `predicateLength`     | `uint16`   | Length of predicate, in instructions.                                 |

--- a/specs/protocol/tx_validity.md
+++ b/specs/protocol/tx_validity.md
@@ -37,7 +37,7 @@ Write-destroy access list:
 - For each [input `InputType.Contract`](./tx_format.md#inputcontract)
   - The [UTXO ID](./identifiers.md#utxo-id) `(txID, outputIndex)`
 - For each [input `InputType.Message`](./tx_format.md#inputmessage)
-  - The [input message ID](./identifiers.md#input-message-id) `messageID`
+  - The [message ID](./identifiers.md#message-id) `messageID`
 
 Write-create access list:
 

--- a/specs/vm/instruction_set.md
+++ b/specs/vm/instruction_set.md
@@ -1400,11 +1400,11 @@ Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
 | name        | type          | description                                                                             |
 |-------------|---------------|-----------------------------------------------------------------------------------------|
 | `type`      | `ReceiptType` | `ReceiptType.MessageOut`                                                                |
-| `messageID` | `byte[32]`    | The messageID as described [here](../protocol/identifiers.md#output-message-id).        |
+| `messageID` | `byte[32]`    | The messageID as described [here](../protocol/identifiers.md#message-id).        |
 | `sender`    | `byte[32]`    | The address of the message sender: `MEM[$fp, 32]`.                                      |
 | `recipient` | `byte[32]`    | The address of the message recipient: `MEM[$rA, 32]`.                                   |
 | `amount`    | `uint64`      | Amount of base asset coins sent with message: `$rD`.                                    |
-| `nonce`     | `byte[32]`    | The message nonce as described [here](../protocol/identifiers.md#output-message-nonce). |
+| `nonce`     | `byte[32]`    | The message nonce as described [here](../protocol/identifiers.md#message-nonce). |
 | `len`       | `uint16`      | Length of message data, in bytes: `$rB`.                                                |
 | `digest`    | `byte[32]`    | [Hash](#s256-sha-2-256) of `MEM[$rA + 32, $rB]`.                                        |
 
@@ -1782,14 +1782,13 @@ Get [fields from the transaction](../protocol/tx_format.md#transaction).
 | `GTF_INPUT_MESSAGE_RECIPIENT`             | `0x116` | Memory address of `tx.inputs[$rB].recipient`     |
 | `GTF_INPUT_MESSAGE_AMOUNT`                | `0x117` | `tx.inputs[$rB].amount`                          |
 | `GTF_INPUT_MESSAGE_NONCE`                 | `0x118` | `tx.inputs[$rB].nonce`                           |
-| `GTF_INPUT_MESSAGE_OWNER`                 | `0x119` | Memory address of `tx.inputs[$rB].owner`         |
-| `GTF_INPUT_MESSAGE_WITNESS_INDEX`         | `0x11A` | `tx.inputs[$rB].witnessIndex`                    |
-| `GTF_INPUT_MESSAGE_DATA_LENGTH`           | `0x11B` | `tx.inputs[$rB].dataLength`                      |
-| `GTF_INPUT_MESSAGE_PREDICATE_LENGTH`      | `0x11C` | `tx.inputs[$rB].predicateLength`                 |
-| `GTF_INPUT_MESSAGE_PREDICATE_DATA_LENGTH` | `0x11D` | `tx.inputs[$rB].predicateDataLength`             |
-| `GTF_INPUT_MESSAGE_DATA`                  | `0x11E` | Memory address of `tx.inputs[$rB].data`          |
-| `GTF_INPUT_MESSAGE_PREDICATE`             | `0x11F` | Memory address of `tx.inputs[$rB].predicate`     |
-| `GTF_INPUT_MESSAGE_PREDICATE_DATA`        | `0x120` | Memory address of `tx.inputs[$rB].predicateData` |
+| `GTF_INPUT_MESSAGE_WITNESS_INDEX`         | `0x119` | `tx.inputs[$rB].witnessIndex`                    |
+| `GTF_INPUT_MESSAGE_DATA_LENGTH`           | `0x11A` | `tx.inputs[$rB].dataLength`                      |
+| `GTF_INPUT_MESSAGE_PREDICATE_LENGTH`      | `0x11B` | `tx.inputs[$rB].predicateLength`                 |
+| `GTF_INPUT_MESSAGE_PREDICATE_DATA_LENGTH` | `0x11C` | `tx.inputs[$rB].predicateDataLength`             |
+| `GTF_INPUT_MESSAGE_DATA`                  | `0x11D` | Memory address of `tx.inputs[$rB].data`          |
+| `GTF_INPUT_MESSAGE_PREDICATE`             | `0x11E` | Memory address of `tx.inputs[$rB].predicate`     |
+| `GTF_INPUT_MESSAGE_PREDICATE_DATA`        | `0x11F` | Memory address of `tx.inputs[$rB].predicateData` |
 | `GTF_OUTPUT_TYPE`                         | `0x201` | `tx.outputs[$rB].type`                           |
 | `GTF_OUTPUT_COIN_TO`                      | `0x202` | Memory address of `tx.outputs[$rB].to`           |
 | `GTF_OUTPUT_COIN_AMOUNT`                  | `0x203` | `tx.outputs[$rB].amount`                         |


### PR DESCRIPTION
This PR moves what previously was referred to as the "owner" from input messages into the "recipient" field. This removes redundancy for messages that didn't need a "recipient" field (like a simple ETH bridging). What was previously used in the "recipient" field can simply be placed in the "data" field. This also simplifies messages and makes the calculation of messageId the same for both input and output messages.