### PR TITLE
Add mint transaction type.

### DIFF
--- a/specs/protocol/tx_format.md
+++ b/specs/protocol/tx_format.md
@@ -44,6 +44,7 @@
 enum  TransactionType : uint8 {
     Script = 0,
     Create = 1,
+    Mint = 2,
 }
 ```
 
@@ -52,7 +53,7 @@ enum  TransactionType : uint8 {
 | name   | type                                                                                      | description       |
 |--------|-------------------------------------------------------------------------------------------|-------------------|
 | `type` | [TransactionType](#transactiontype)                                                       | Transaction type. |
-| `data` | One of [TransactionScript](#transactionscript) or [TransactionCreate](#transactioncreate) | Transaction data. |
+| `data` | One of [TransactionScript](#transactionscript), [TransactionCreate](#transactioncreate), or [TransactionMint](#transactionmint) | Transaction data. |
 
 Transaction is invalid if:
 
@@ -165,6 +166,18 @@ Transaction is invalid if:
 - The [Sparse Merkle tree](./cryptographic_primitives.md#sparse-merkle-tree) root of `storageSlots` is not equal to the `stateRoot` of the one `OutputType.ContractCreated` output
 
 Creates a contract with contract ID as computed [here](./identifiers.md#contract-id).
+
+## TransactionMint
+
+| name               | type                    | description                              |
+|--------------------|-------------------------|------------------------------------------|
+| `outputsCount`     | `uint8`                 | Number of outputs.                       |
+| `outputs`          | [Output](#output)`[]`   | List of outputs.                         |
+
+Transaction is invalid if:
+
+- Any output is not of type `OutputType.Coin`
+- Any two outputs have the same `asset_id`
 
 ## InputType
 


### PR DESCRIPTION
Partially addresses #286.

Add a new transaction type, `Mint`, that only contains outputs. In the general case, no validation of this transaction is necessary beyond checking for well-formedness. Note that this PR doesn't actually allow mint transactions anywhere, it only defines a new transaction type.

Two applications exist:
1. A coinbase tx, i.e. #286. This will require a block validation rule to check that the first tx is a mint tx and that the values are constrained.
2. Block-level flash loans. https://twitter.com/aeyakovenko/status/1568429252332384257 A mint tx must be paired with an equivalent burn (e.g. a tx with only inputs and no outputs).