### PR TITLE
Add data field to panic receipt

### DIFF
--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -553,16 +553,18 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 - `type`: `Panic`.
 - `id`: Hexadecimal string representation of the 256-bit (32-byte) contract ID of the current context if in an internal context. `null` otherwise.
 - `reason`: Decimal string representation of an 8-bit unsigned integer; panic reason.
+- `data`: Hexadecimal string representation of the 256-bit (32-byte) contract ID or asset ID related to the error. `null` otherwise.
 - `pc`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$pc`.
 - `is`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$is`.
 
 ```json
 {
-  "type":"Panic",
-  "id":"0x39150017c9e38e5e280432d546fae345d6ce6d8fe4710162c2e3a95a6faff051",
-  "reason":"1",
-  "pc":"0xffffffffffffffff",
-  "is":"0xfffffffffffffffe"
+  "type": "Panic",
+  "id": "0x39150017c9e38e5e280432d546fae345d6ce6d8fe4710162c2e3a95a6faff051",
+  "reason": "1",
+  "data": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "pc": "0xffffffffffffffff",
+  "is": "0xfffffffffffffffe"
 }
 ```
 

--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -555,7 +555,7 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 - `reason`: Decimal string representation of an 8-bit unsigned integer; panic reason.
 - `pc`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$pc`.
 - `is`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$is`.
-- `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) contract ID if applicable. `null` otherwise. 
+- `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) contract ID if applicable. `null` otherwise.
 Not included in canonical receipt form. Primary use is for access-list estimation by SDK.
 
 ```json

--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -555,7 +555,8 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 - `reason`: Decimal string representation of an 8-bit unsigned integer; panic reason.
 - `pc`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$pc`.
 - `is`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$is`.
-- `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) problematic contract ID if applicable. `null` otherwise. Not included in canonical receipt form.
+- `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) contract ID if applicable. `null` otherwise. Not included in canonical receipt form. 
+Primary use is for access-list estimation by SDK.
 
 ```json
 {

--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -555,8 +555,8 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 - `reason`: Decimal string representation of an 8-bit unsigned integer; panic reason.
 - `pc`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$pc`.
 - `is`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$is`.
-- `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) contract ID if applicable. `null` otherwise. Not included in canonical receipt form. 
-Primary use is for access-list estimation by SDK.
+- `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) contract ID if applicable. `null` otherwise. 
+Not included in canonical receipt form. Primary use is for access-list estimation by SDK.
 
 ```json
 {

--- a/specs/protocol/abi.md
+++ b/specs/protocol/abi.md
@@ -553,18 +553,18 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 - `type`: `Panic`.
 - `id`: Hexadecimal string representation of the 256-bit (32-byte) contract ID of the current context if in an internal context. `null` otherwise.
 - `reason`: Decimal string representation of an 8-bit unsigned integer; panic reason.
-- `data`: Hexadecimal string representation of the 256-bit (32-byte) contract ID or asset ID related to the error. `null` otherwise.
 - `pc`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$pc`.
 - `is`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$is`.
+- `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) problematic contract ID if applicable. `null` otherwise. Not included in canonical receipt form.
 
 ```json
 {
   "type": "Panic",
   "id": "0x39150017c9e38e5e280432d546fae345d6ce6d8fe4710162c2e3a95a6faff051",
   "reason": "1",
-  "data": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "pc": "0xffffffffffffffff",
-  "is": "0xfffffffffffffffe"
+  "is": "0xfffffffffffffffe",
+  "contractId": "0x0000000000000000000000000000000000000000000000000000000000000000"
 }
 ```
 

--- a/specs/vm/instruction_set.md
+++ b/specs/vm/instruction_set.md
@@ -99,12 +99,14 @@ Some instructions may _panic_, i.e. enter an unrecoverable state. Additionally, 
 
 On a non-predicate panic, append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
 
-| name   | type          | description                                                               |
-|--------|---------------|---------------------------------------------------------------------------|
-| `type` | `ReceiptType` | `ReceiptType.Panic`                                                       |
-| `id`   | `byte[32]`    | Contract ID of current context if in an internal context, zero otherwise. |
-| `pc`   | `uint64`      | Value of register `$pc`.                                                  |
-| `is`   | `uint64`      | Value of register `$is`.                                                  |
+| name     | type          | description                                                                    |
+|----------|---------------|--------------------------------------------------------------------------------|
+| `type`   | `ReceiptType` | `ReceiptType.Panic`                                                            |
+| `id`     | `byte[32]`    | Contract ID of current context if in an internal context, zero otherwise.      |
+| `pc`     | `uint64`      | Value of register `$pc`.                                                       |
+| `is`     | `uint64`      | Value of register `$is`.                                                       |
+| `reason` | `uint8`       | The panic reason identifier                                                    |
+| `data`   | `byte[32]`    | ContractId or AssetID associated with the panic if applicable, zero otherwise. |
 
 then append an additional receipt to the list of receipts, again modifying `tx.receiptsRoot`:
 
@@ -1002,7 +1004,7 @@ Panic if:
 - `$rB + 32 > VM_MAX_RAM`
 - `$rC + 32` overflows
 - `$rC + 32 > VM_MAX_RAM`
-- Contract with ID `MEM[$rC, 32]` is not in `tx.inputs`
+- Contract with ID `MEM[$rC, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rC, 32]` in panic receipt data.
 
 ### BHEI: Block height
 
@@ -1071,10 +1073,10 @@ Panic if:
 
 - `$rA + 32` overflows
 - `$rC + 32` overflows
-- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
+- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rA, 32]` in panic receipt data.
 - Reading past `MEM[VM_MAX_RAM - 1]`
-- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`
-- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
+- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
+- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
 
 Register `$rA` is a memory address from which the following fields are set (word-aligned):
 
@@ -1150,7 +1152,7 @@ Panic if:
 - `$rB + 32 > VM_MAX_RAM`
 - The memory range `MEM[$rA, $rD]`  does not pass [ownership check](./main.md#ownership)
 - `$rD > MEM_MAX_ACCESS_SIZE`
-- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
+- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rB, 32]` in panic receipt data.
 
 ### CROO: Code Merkle root
 
@@ -1169,7 +1171,7 @@ Panic if:
 - `$rA + 32 > VM_MAX_RAM`
 - `$rB + 32 > VM_MAX_RAM`
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
-- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
+- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rB, 32]` in panic receipt data.
 
 Code root computation is defined [here](../protocol/identifiers.md#contract-id).
 
@@ -1188,7 +1190,7 @@ Panic if:
 - `$rA` is a [reserved register](./main.md#semantics)
 - `$rB + 32` overflows
 - `$rB + 32 > VM_MAX_RAM`
-- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
+- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rB, 32]` in panic receipt data.
 
 ### LDC: Load code from an external contract
 
@@ -1210,7 +1212,7 @@ Panic if:
 - `$ssp + $rC > $hp`
 - `$rC > CONTRACT_MAX_SIZE`
 - `$rC > MEM_MAX_ACCESS_SIZE`
-- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
+- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rA, 32]` in panic receipt data.
 
 Increment `$fp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word alignment.
 
@@ -1524,9 +1526,9 @@ Panic if:
 - `$rC + 32` overflows
 - `$rA + 32 > VM_MAX_RAM`
 - `$rC + 32 > VM_MAX_RAM`
-- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
-- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`
-- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
+- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rA, 32]` in panic receipt data.
+- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
+- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
 - `$rB == 0`
 
 Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
@@ -1564,8 +1566,8 @@ Panic if:
 - `$rA + 32 > VM_MAX_RAM`
 - `$rD + 32 > VM_MAX_RAM`
 - `$rB > tx.outputsCount`
-- In an external context, if `$rC > MEM[balanceOfStart(MEM[$rD, 32]), 8]`
-- In an internal context, if `$rC` is greater than the balance of asset ID `MEM[$rD, 32]` of output with contract ID `MEM[$fp, 32]`
+- In an external context, if `$rC > MEM[balanceOfStart(MEM[$rD, 32]), 8]`. Include asset ID `MEM[$rD, 32]` in panic receipt data.
+- In an internal context, if `$rC` is greater than the balance of asset ID `MEM[$rD, 32]` of output with contract ID `MEM[$fp, 32]`. Include asset ID `MEM[$rD, 32]` in panic receipt data.
 - `$rC == 0`
 - `tx.outputs[$rB].type != OutputType.Variable`
 - `tx.outputs[$rB].amount != 0`

--- a/specs/vm/instruction_set.md
+++ b/specs/vm/instruction_set.md
@@ -99,14 +99,12 @@ Some instructions may _panic_, i.e. enter an unrecoverable state. Additionally, 
 
 On a non-predicate panic, append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
 
-| name     | type          | description                                                                    |
-|----------|---------------|--------------------------------------------------------------------------------|
-| `type`   | `ReceiptType` | `ReceiptType.Panic`                                                            |
-| `id`     | `byte[32]`    | Contract ID of current context if in an internal context, zero otherwise.      |
-| `pc`     | `uint64`      | Value of register `$pc`.                                                       |
-| `is`     | `uint64`      | Value of register `$is`.                                                       |
-| `reason` | `uint8`       | The panic reason identifier                                                    |
-| `data`   | `byte[32]`    | ContractId or AssetID associated with the panic if applicable, zero otherwise. |
+| name   | type          | description                                                               |
+|--------|---------------|---------------------------------------------------------------------------|
+| `type` | `ReceiptType` | `ReceiptType.Panic`                                                       |
+| `id`   | `byte[32]`    | Contract ID of current context if in an internal context, zero otherwise. |
+| `pc`   | `uint64`      | Value of register `$pc`.                                                  |
+| `is`   | `uint64`      | Value of register `$is`.                                                  |
 
 then append an additional receipt to the list of receipts, again modifying `tx.receiptsRoot`:
 
@@ -1004,7 +1002,7 @@ Panic if:
 - `$rB + 32 > VM_MAX_RAM`
 - `$rC + 32` overflows
 - `$rC + 32 > VM_MAX_RAM`
-- Contract with ID `MEM[$rC, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rC, 32]` in panic receipt data.
+- Contract with ID `MEM[$rC, 32]` is not in `tx.inputs`
 
 ### BHEI: Block height
 
@@ -1073,10 +1071,10 @@ Panic if:
 
 - `$rA + 32` overflows
 - `$rC + 32` overflows
-- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rA, 32]` in panic receipt data.
+- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
 - Reading past `MEM[VM_MAX_RAM - 1]`
-- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
-- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
+- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`
+- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
 
 Register `$rA` is a memory address from which the following fields are set (word-aligned):
 
@@ -1152,7 +1150,7 @@ Panic if:
 - `$rB + 32 > VM_MAX_RAM`
 - The memory range `MEM[$rA, $rD]`  does not pass [ownership check](./main.md#ownership)
 - `$rD > MEM_MAX_ACCESS_SIZE`
-- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rB, 32]` in panic receipt data.
+- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
 
 ### CROO: Code Merkle root
 
@@ -1171,7 +1169,7 @@ Panic if:
 - `$rA + 32 > VM_MAX_RAM`
 - `$rB + 32 > VM_MAX_RAM`
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./main.md#ownership)
-- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rB, 32]` in panic receipt data.
+- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
 
 Code root computation is defined [here](../protocol/identifiers.md#contract-id).
 
@@ -1190,7 +1188,7 @@ Panic if:
 - `$rA` is a [reserved register](./main.md#semantics)
 - `$rB + 32` overflows
 - `$rB + 32 > VM_MAX_RAM`
-- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rB, 32]` in panic receipt data.
+- Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
 
 ### LDC: Load code from an external contract
 
@@ -1212,7 +1210,7 @@ Panic if:
 - `$ssp + $rC > $hp`
 - `$rC > CONTRACT_MAX_SIZE`
 - `$rC > MEM_MAX_ACCESS_SIZE`
-- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rA, 32]` in panic receipt data.
+- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
 
 Increment `$fp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word alignment.
 
@@ -1526,9 +1524,9 @@ Panic if:
 - `$rC + 32` overflows
 - `$rA + 32 > VM_MAX_RAM`
 - `$rC + 32 > VM_MAX_RAM`
-- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`. Include Contract ID `MEM[$rA, 32]` in panic receipt data.
-- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
-- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`. Include asset ID `MEM[$rC, 32]` in panic receipt data.
+- Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
+- In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`
+- In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
 - `$rB == 0`
 
 Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
@@ -1566,8 +1564,8 @@ Panic if:
 - `$rA + 32 > VM_MAX_RAM`
 - `$rD + 32 > VM_MAX_RAM`
 - `$rB > tx.outputsCount`
-- In an external context, if `$rC > MEM[balanceOfStart(MEM[$rD, 32]), 8]`. Include asset ID `MEM[$rD, 32]` in panic receipt data.
-- In an internal context, if `$rC` is greater than the balance of asset ID `MEM[$rD, 32]` of output with contract ID `MEM[$fp, 32]`. Include asset ID `MEM[$rD, 32]` in panic receipt data.
+- In an external context, if `$rC > MEM[balanceOfStart(MEM[$rD, 32]), 8]`
+- In an internal context, if `$rC` is greater than the balance of asset ID `MEM[$rD, 32]` of output with contract ID `MEM[$fp, 32]`
 - `$rC == 0`
 - `tx.outputs[$rB].type != OutputType.Variable`
 - `tx.outputs[$rB].amount != 0`


### PR DESCRIPTION
When the SDK is trying to estimate which contracts should be added to the inputs of a transaction, it is only able to obtain a u8 panic reason from the VM without any additional info about what contract ID was expected to be in the inputs. While the VM knows what contract ID is missing from the inputs, the ABI spec currently doesn't provide any way for the VM to return it.

One way this could be handled is by adding a new 32 byte `data` field to panic receipts, which is what is contained in this PR proposal. A 32 byte data field on panic receipts could also be used for reporting an asset ID when doing ops like `TR` or `TRO`, to indicate which asset has insufficient balance.

This would help unblock https://github.com/FuelLabs/fuels-rs/issues/595