### PR TITLE
Fix redirect

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,4 +9,4 @@ title = "Fuel Specifications"
 git-repository-url = "https://github.com/FuelLabs/fuel-specs"
 
 [output.html.redirect]
-"/protocol/abi.html" = "/protocol/abi/index.html"
+"/protocol/abi.html" = "./abi/index.html"


### PR DESCRIPTION
This PR fixes the redirection introduced in #433.

Example route: `https://fuellabs.github.io/fuel-specs/master/protocol/abi`
Old redirection: `https://fuellabs.github.io/protocol/abi/index.html` (No `fuel-specs/master/`, it's broken.)
New redirection: `https://fuellabs.github.io/fuel-specs/master/protocol/abi/index.html` (All good.)