### PR TITLE
fixed improper range description on SRWQ

### DIFF
--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -1463,7 +1463,7 @@ Register `$rB` will be set to `false` if any storage slot in the requested range
 |             |                                                                            |
 |-------------|----------------------------------------------------------------------------|
 | Description | A sequential series of 32 bytes is read from the current contract's state. |
-| Operation   | ```MEM[$rA, 32 * rD] = STATE[MEM[$rC, 32 * rD]];```                        |
+| Operation   | ```MEM[$rA, 32 * rD] = STATE[MEM[$rC, 32], 32 * rD];```                    |
 | Syntax      | `srwq $rA, $rB, $rC, $rD`                                                  |
 | Encoding    | `0x00 rA rB rC rD`                                                         |
 | Notes       | Returns zero if the state element does not exist.                          |


### PR DESCRIPTION
SRWQ Description stated that state retrieval would occur for a range of keys specified starting at a single location in memory, instead of a range from state extending from a single specified key.