### PR TITLE
Add function attributes to JSON ABI

### DIFF
--- a/src/protocol/abi/json_abi_format.md
+++ b/src/protocol/abi/json_abi_format.md
@@ -49,6 +49,7 @@ The ABI of a contract is represented as a JSON object containing the following p
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the output, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
       - `"type"`: the _type declaration_ ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
+  - `"attributes"`: an optional array of attribute names.
 - `"loggedTypes"`: an array describing all instances of [`log`](../../vm/instruction_set.md#log-log-event) or [`logd`](../../vm/instruction_set.md#logd-log-data-event) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
   - `"logId"`: a unique integer ID. The [`log`](../../vm/instruction_set.md#log-log-event) and [`logd`](../../vm/instruction_set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
   - `"loggedType"`: a _type application_ represented as a JSON object that contains the following properties:
@@ -439,6 +440,7 @@ struct MyStruct {
 }
 
 abi MyContract {
+    #[payable]
     fn complex_function(
         arg1: ([str[5]; 3], bool, b256),
         arg2: MyStruct,
@@ -568,7 +570,8 @@ its JSON representation would look like:
       "output": {
         "type": 0,
         "typeArguments": null
-      }
+      },
+      "attributes": ["payable"]
     }
   ],
   "loggedTypes": []

--- a/src/protocol/abi/json_abi_format.md
+++ b/src/protocol/abi/json_abi_format.md
@@ -49,7 +49,11 @@ The ABI of a contract is represented as a JSON object containing the following p
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the output, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
       - `"type"`: the _type declaration_ ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"attributes"`: an optional array of attribute names.
+  - `"attributes"`: an optional array of _attributes_. Each _attribute_ is represented as a JSON object that contains
+  the following properties:
+    - `"name"`: the name of the attribute (the only valid attribute names are `storage`, `payable`, `test`, `inline`,
+    `doc`, `doc-comment`).
+    - `"arguments"`: an optional array of attribute arguments.
 - `"loggedTypes"`: an array describing all instances of [`log`](../../vm/instruction_set.md#log-log-event) or [`logd`](../../vm/instruction_set.md#logd-log-data-event) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
   - `"logId"`: a unique integer ID. The [`log`](../../vm/instruction_set.md#log-log-event) and [`logd`](../../vm/instruction_set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
   - `"loggedType"`: a _type application_ represented as a JSON object that contains the following properties:
@@ -447,7 +451,8 @@ struct MyStruct {
 }
 
 abi MyContract {
-    #[payable]
+    /// this is a doc comment
+    #[payable, storage(read, write)]
     fn complex_function(
         arg1: ([str[5]; 3], bool, b256),
         arg2: MyStruct,
@@ -578,7 +583,19 @@ its JSON representation would look like:
         "type": 0,
         "typeArguments": null
       },
-      "attributes": ["payable"]
+      "attributes": [
+        {
+          "name": "doc-comment",
+          "arguments": [" this is a doc comment"]
+        },
+        {
+          "name": "payable",
+        },
+        {
+          "name": "storage",
+          "arguments": ["read", "write"]
+        }
+      ]
     }
   ],
   "loggedTypes": []

--- a/src/protocol/abi/json_abi_format.md
+++ b/src/protocol/abi/json_abi_format.md
@@ -49,7 +49,7 @@ The ABI of a contract is represented as a JSON object containing the following p
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the output, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
       - `"type"`: the _type declaration_ ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"attributes"`: an array of _attributes_. Each _attribute_ is represented as a JSON object that contains
+  - `"attributes"`: an optional array of _attributes_. Each _attribute_ is represented as a JSON object that contains
   the following properties:
     - `"name"`: the name of the attribute (the only valid attribute names are `storage`, `payable`, `test`, `inline`,
     `doc`, `doc-comment`).
@@ -133,8 +133,7 @@ the JSON representation of this ABI looks like:
       "output": {
         "type": 2,
         "typeArguments": null
-      },
-      "attributes": []
+      }
     },
     {
       "inputs": [
@@ -148,8 +147,7 @@ the JSON representation of this ABI looks like:
       "output": {
         "type": 0,
         "typeArguments": null
-      },
-      "attributes": []
+      }
     }
   ],
   "loggedTypes": []
@@ -716,8 +714,7 @@ its JSON representation would look like:
       "output": {
         "type": 0,
         "typeArguments": null
-      },
-      "attributes": []
+      }
     }
   ],
   "loggedTypes": []
@@ -794,8 +791,7 @@ its JSON representation would look like:
       "output": {
         "type": 0,
         "typeArguments": null
-      },
-      "attributes": []
+      }
     }
   ],
   "loggedTypes": [

--- a/src/protocol/abi/json_abi_format.md
+++ b/src/protocol/abi/json_abi_format.md
@@ -49,11 +49,9 @@ The ABI of a contract is represented as a JSON object containing the following p
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the output, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
       - `"type"`: the _type declaration_ ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"attributes"`: an optional array of _attributes_. Each _attribute_ is represented as a JSON object that contains
-  the following properties:
-    - `"name"`: the name of the attribute (the only valid attribute names are `storage`, `payable`, `test`, `inline`,
-    `doc`, `doc-comment`).
-    - `"arguments"`: an optional array of attribute arguments.
+  - `"attributes"`: an optional array of _attributes_. Each _attribute_ is explained in the [dedicated section](#attributes-semantics) and is represented as a JSON object that contains the following properties:
+    - `"name"`: the name of the attribute.
+    - `"arguments"`: an array of attribute arguments.
 - `"loggedTypes"`: an array describing all instances of [`log`](../../vm/instruction_set.md#log-log-event) or [`logd`](../../vm/instruction_set.md#logd-log-data-event) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
   - `"logId"`: a unique integer ID. The [`log`](../../vm/instruction_set.md#log-log-event) and [`logd`](../../vm/instruction_set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
   - `"loggedType"`: a _type application_ represented as a JSON object that contains the following properties:
@@ -78,6 +76,17 @@ The ABI of a contract is represented as a JSON object containing the following p
   - `"offset"`: the specific offset within the contract's bytecode, in bytes, to the data section entry for the `configurable` variable.
 
 > **Note**: This JSON should be both human-readable and parsable by the tooling around the FuelVM and the Sway programming language. There is a detailed specification for the binary encoding backing this readable descriptor. The [Function Selector Encoding](./fn_selector_encoding.md) section specifies the encoding for the function being selected to be executed and each of the argument types.
+
+### Attributes Semantics
+
+| Attribute name | Attribute arguments               | Semantics |
+| -------------- | --------------------------------- | --------- |
+| `storage`      | `read` and/or `write`             | Specifies if a function reads or writes to/from storage |
+| `payable`      | None                              | Specifies if a function can accept coins: a function without `payable` attribute must not accept coins |
+| `test`         | None                              | Specifies if a function is a unit test |
+| `inline`       | `never` or `always`, but not both | Specifies if a function should be inlined during code generation |
+| `doc-comment`  | String                            | Documentation comment |
+| `doc`          | Not defined yet                   | Not defined yet |
 
 ## A Simple Example
 

--- a/src/protocol/abi/json_abi_format.md
+++ b/src/protocol/abi/json_abi_format.md
@@ -79,14 +79,14 @@ The ABI of a contract is represented as a JSON object containing the following p
 
 ### Attributes Semantics
 
-| Attribute name | Attribute arguments               | Semantics |
-| -------------- | --------------------------------- | --------- |
-| `storage`      | `read` and/or `write`             | Specifies if a function reads or writes to/from storage |
+| Attribute name | Attribute arguments               | Semantics                                                                                              |
+|----------------|-----------------------------------|--------------------------------------------------------------------------------------------------------|
+| `storage`      | `read` and/or `write`             | Specifies if a function reads or writes to/from storage                                                |
 | `payable`      | None                              | Specifies if a function can accept coins: a function without `payable` attribute must not accept coins |
-| `test`         | None                              | Specifies if a function is a unit test |
-| `inline`       | `never` or `always`, but not both | Specifies if a function should be inlined during code generation |
-| `doc-comment`  | String                            | Documentation comment |
-| `doc`          | Not defined yet                   | Not defined yet |
+| `test`         | None                              | Specifies if a function is a unit test                                                                 |
+| `inline`       | `never` or `always`, but not both | Specifies if a function should be inlined during code generation                                       |
+| `doc-comment`  | String                            | Documentation comment                                                                                  |
+| `doc`          | Not defined yet                   | Not defined yet                                                                                        |
 
 ## A Simple Example
 

--- a/src/protocol/abi/json_abi_format.md
+++ b/src/protocol/abi/json_abi_format.md
@@ -49,7 +49,7 @@ The ABI of a contract is represented as a JSON object containing the following p
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the output, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
       - `"type"`: the _type declaration_ ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"attributes"`: an optional array of _attributes_. Each _attribute_ is represented as a JSON object that contains
+  - `"attributes"`: an array of _attributes_. Each _attribute_ is represented as a JSON object that contains
   the following properties:
     - `"name"`: the name of the attribute (the only valid attribute names are `storage`, `payable`, `test`, `inline`,
     `doc`, `doc-comment`).
@@ -133,7 +133,8 @@ the JSON representation of this ABI looks like:
       "output": {
         "type": 2,
         "typeArguments": null
-      }
+      },
+      "attributes": []
     },
     {
       "inputs": [
@@ -147,7 +148,8 @@ the JSON representation of this ABI looks like:
       "output": {
         "type": 0,
         "typeArguments": null
-      }
+      },
+      "attributes": []
     }
   ],
   "loggedTypes": []
@@ -714,7 +716,8 @@ its JSON representation would look like:
       "output": {
         "type": 0,
         "typeArguments": null
-      }
+      },
+      "attributes": []
     }
   ],
   "loggedTypes": []
@@ -791,7 +794,8 @@ its JSON representation would look like:
       "output": {
         "type": 0,
         "typeArguments": null
-      }
+      },
+      "attributes": []
     }
   ],
   "loggedTypes": [


### PR DESCRIPTION
close #446

I went for one of the simplest solutions here. I'd propose to switch to a more complex attribute representation when the need arises -- the current format does not support attributes with parameters. But I'm happy to take suggestions on this as well and switch to a more general schema if someone has potential use cases in mind.

### TODOs based on an internal discussion

- [x] Document possible function attributes
- [x] Add doc comment attributes
- [x] Add storage attributes