### PR TITLE
Refactor of retryable messages

### DIFF
--- a/src/protocol/tx_format/input.md
+++ b/src/protocol/tx_format/input.md
@@ -19,19 +19,20 @@ Transaction is invalid if:
 
 ## InputCoin
 
-| name                  | type                                   | description                                         |
-|-----------------------|----------------------------------------|-----------------------------------------------------|
-| `txID`                | `byte[32]`                             | Hash of transaction.                                |
-| `outputIndex`         | `uint8`                                | Index of transaction output.                        |
-| `owner`               | `byte[32]`                             | Owning address or predicate root.                   |
-| `amount`              | `uint64`                               | Amount of coins.                                    |
-| `asset_id`            | `byte[32]`                             | Asset ID of the coins.                              |
-| `txPointer`           | [TXPointer](./tx_pointer.md)           | Points to the TX whose output is being spent.       |
-| `witnessIndex`        | `uint8`                                | Index of witness that authorizes spending the coin. |
-| `predicateLength`     | `uint16`                               | Length of predicate, in instructions.               |
-| `predicateDataLength` | `uint16`                               | Length of predicate input data, in bytes.           |
-| `predicate`           | `byte[]`                               | Predicate bytecode.                                 |
-| `predicateData`       | `byte[]`                               | Predicate input data (parameters).                  |
+| name                  | type                         | description                                                            |
+|-----------------------|------------------------------|------------------------------------------------------------------------|
+| `txID`                | `byte[32]`                   | Hash of transaction.                                                   |
+| `outputIndex`         | `uint8`                      | Index of transaction output.                                           |
+| `owner`               | `byte[32]`                   | Owning address or predicate root.                                      |
+| `amount`              | `uint64`                     | Amount of coins.                                                       |
+| `asset_id`            | `byte[32]`                   | Asset ID of the coins.                                                 |
+| `txPointer`           | [TXPointer](./tx_pointer.md) | Points to the TX whose output is being spent.                          |
+| `witnessIndex`        | `uint8`                      | Index of witness that authorizes spending the coin.                    |
+| `maturity`            | `uint32`                     | UTXO being spent must have been created at least this many blocks ago. |
+| `predicateLength`     | `uint16`                     | Length of predicate, in instructions.                                  |
+| `predicateDataLength` | `uint16`                     | Length of predicate input data, in bytes.                              |
+| `predicate`           | `byte[]`                     | Predicate bytecode.                                                    |
+| `predicateData`       | `byte[]`                     | Predicate input data (parameters).                                     |
 
 Given helper `len()` that returns the number of bytes of a field.
 

--- a/src/protocol/tx_format/input.md
+++ b/src/protocol/tx_format/input.md
@@ -19,21 +19,19 @@ Transaction is invalid if:
 
 ## InputCoin
 
-| name                  | type                                   | description                                                            |
-|-----------------------|----------------------------------------|------------------------------------------------------------------------|
-| `txID`                | `byte[32]`                             | Hash of transaction or ID of originating message ID.                   |
-| `outputIndex`         | `uint8`                                | Index of transaction output.                                           |
-| `owner`               | `byte[32]`                             | Owning address or predicate root.                                      |
-| `amount`              | `uint64`                               | Amount of coins.                                                       |
-| `asset_id`            | `byte[32]`                             | Asset ID of the coins.                                                 |
-| `txPointer`           | [TXPointer](./tx_pointer.md)           | Points to the TX whose output is being spent.                          |
-| `messagePointer`      | [MessagePointer](./message_pointer.md) | Points to the message being spent.                                     |
-| `witnessIndex`        | `uint8`                                | Index of witness that authorizes spending the coin.                    |
-| `maturity`            | `uint32`                               | UTXO being spent must have been created at least this many blocks ago. |
-| `predicateLength`     | `uint16`                               | Length of predicate, in instructions.                                  |
-| `predicateDataLength` | `uint16`                               | Length of predicate input data, in bytes.                              |
-| `predicate`           | `byte[]`                               | Predicate bytecode.                                                    |
-| `predicateData`       | `byte[]`                               | Predicate input data (parameters).                                     |
+| name                  | type                                   | description                                         |
+|-----------------------|----------------------------------------|-----------------------------------------------------|
+| `txID`                | `byte[32]`                             | Hash of transaction.                                |
+| `outputIndex`         | `uint8`                                | Index of transaction output.                        |
+| `owner`               | `byte[32]`                             | Owning address or predicate root.                   |
+| `amount`              | `uint64`                               | Amount of coins.                                    |
+| `asset_id`            | `byte[32]`                             | Asset ID of the coins.                              |
+| `txPointer`           | [TXPointer](./tx_pointer.md)           | Points to the TX whose output is being spent.       |
+| `witnessIndex`        | `uint8`                                | Index of witness that authorizes spending the coin. |
+| `predicateLength`     | `uint16`                               | Length of predicate, in instructions.               |
+| `predicateDataLength` | `uint16`                               | Length of predicate input data, in bytes.           |
+| `predicate`           | `byte[]`                               | Predicate bytecode.                                 |
+| `predicateData`       | `byte[]`                               | Predicate input data (parameters).                  |
 
 Given helper `len()` that returns the number of bytes of a field.
 
@@ -48,13 +46,11 @@ Transaction is invalid if:
 
 If `h` is the block height the UTXO being spent was created, transaction is invalid if `blockheight() < h + maturity`.
 
-> **Note:** when signing a transaction, `txPointer` and `messagePointer` are set to zero.
+> **Note:** when signing a transaction, `txPointer` is set to zero.
 >
-> **Note:** when verifying a predicate, `txPointer` and `messagePointer` are initialized to zero.
+> **Note:** when verifying a predicate, `txPointer` is initialized to zero.
 >
-> **Note:** when executing a script, `txPointer` and `messagePointer` are initialized to zero.
->
-> **Note:** a message from the base chain with data length of zero is spent as a coin input using the message ID as the `txID` and `outputIndex` set to zero.
+> **Note:** when executing a script, `txPointer` is initialized to zero.
 
 The predicate root is computed identically to the contract root, used to compute the contract ID, [here](../id/contract.md).
 
@@ -102,11 +98,10 @@ Given helper `len()` that returns the number of bytes of a field.
 Transaction is invalid if:
 
 - `witnessIndex >= tx.witnessesCount`
-- `dataLength == 0`
 - `dataLength > MAX_MESSAGE_DATA_LENGTH`
 - `predicateLength > MAX_PREDICATE_LENGTH`
 - `predicateDataLength > MAX_PREDICATE_DATA_LENGTH`
-- If `predicateLength > 0`; the computed predicate root (see below) is not equal `owner`
+- If `predicateLength > 0`; the computed predicate root (see below) is not equal `recipient`
 - `dataLength != len(data)`
 - `predicateLength * 4 != len(predicate)`
 - `predicateDataLength != len(predicateData)`
@@ -119,6 +114,6 @@ The predicate root is computed identically to the contract root, used to compute
 >
 > **Note:** when executing a script, `messagePointer` is initialized to zero.
 >
-> **Note:** a message from the base chain with data length of zero is spent as a coin input using the message ID as the `txID` and `outputIndex` set to zero.
+> **Note:** a message from the base chain with data length of zero is spendable in a similar manner to `InputType.Coin`.
 >
-> **Note:** `InputMessages` are not considered spent until they are included in a transaction of type `TransactionType.Script` with a `ScriptResult` receipt where `result` is equal to `0` indicating a successful script exit
+> **Note:** `InputMessages` with data length greater than zero are not considered spent until they are included in a transaction of type `TransactionType.Script` with a `ScriptResult` receipt where `result` is equal to `0` indicating a successful script exit

--- a/src/protocol/tx_format/transaction.md
+++ b/src/protocol/tx_format/transaction.md
@@ -21,7 +21,7 @@ Transaction is invalid if:
 - `inputsCount > MAX_INPUTS`
 - `outputsCount > MAX_OUTPUTS`
 - `witnessesCount > MAX_WITNESSES`
-- No inputs are of type `InputType.Coin` or `InputType.Message`
+- No inputs are of type `InputType.Coin` or `InputType.Message` with `input.dataLength` > 0
 - More than one output is of type `OutputType.Change` for any asset ID in the input set
 - Any output is of type `OutputType.Change` for any asset ID not in the input set
 - More than one input of type `InputType.Coin` for any [Coin ID](../id/utxo.md#coin-id) in the input set

--- a/src/protocol/tx_format/transaction.md
+++ b/src/protocol/tx_format/transaction.md
@@ -21,7 +21,7 @@ Transaction is invalid if:
 - `inputsCount > MAX_INPUTS`
 - `outputsCount > MAX_OUTPUTS`
 - `witnessesCount > MAX_WITNESSES`
-- No inputs are of type `InputType.Coin` or `InputType.Message` with `input.dataLength` > 0
+- No inputs are of type `InputType.Coin` or `InputType.Message` with `input.dataLength` == 0
 - More than one output is of type `OutputType.Change` for any asset ID in the input set
 - Any output is of type `OutputType.Change` for any asset ID not in the input set
 - More than one input of type `InputType.Coin` for any [Coin ID](../id/utxo.md#coin-id) in the input set

--- a/src/protocol/tx_validity.md
+++ b/src/protocol/tx_validity.md
@@ -87,11 +87,14 @@ If this check passes, the UTXO ID `(txID, outputIndex)` fields of each contract 
 For each asset ID `asset_id` in the input and output set:
 
 ```py
-def sum_messages(tx, asset_id) -> int:
+def sum_data_messages(tx, asset_id) -> int:
+    """
+    Returns the total balance available from messages containing data
+    """
     total: int = 0
     if asset_id == 0:
         for input in tx.inputs:
-            if input.type == InputType.Message:
+            if input.type == InputType.Message and input.dataLength > 0:
                 total += input.amount
     return total
 
@@ -99,6 +102,8 @@ def sum_inputs(tx, asset_id) -> int:
     total: int = 0
     for input in tx.inputs:
         if input.type == InputType.Coin and input.asset_id == asset_id:
+            total += input.amount
+        elif input.type == InputType.Message and asset_id == 0 and input.dataLength == 0:
             total += input.amount
     return total
 
@@ -109,12 +114,11 @@ def sum_outputs(tx, asset_id) -> int:
             total += output.amount
     return total
 
-def message_balance(tx, asset_id) -> int:
-    messageBalance = sum_messages(tx, asset_id)
-    return messageBalance
-
 def available_balance(tx, asset_id) -> int:
-    availableBalance = sum_inputs(tx, asset_id) + sum_messages(tx, asset_id)
+    """
+    Make the data message balance available to the script
+    """
+    availableBalance = sum_inputs(tx, asset_id) + sum_data_messages(tx, asset_id)
     return availableBalance
 
 def unavailable_balance(tx, asset_id) -> int:
@@ -128,14 +132,15 @@ def unavailable_balance(tx, asset_id) -> int:
     bytesBalance = size(tx) * GAS_PER_BYTE * gasPrice / GAS_PRICE_FACTOR
     # Total fee balance
     feeBalance = ceiling(gasBalance + bytesBalance)
-    # Total message balance
-    messageBalance = sum_messages(tx, asset_id)
     # Only base asset can be used to pay for gas
     if asset_id == 0:
-        return sentBalance + feeBalance + messageBalance
+        return sentBalance + feeBalance
     return sentBalance
 
-return available_balance(tx, asset_id) >= unavailable_balance(tx, asset_id)
+# sum_data_messages is not included in the unavailable_balance since it is spendable as long as there is enough
+# base asset amount to cover gas costs without using data messages. Messages containing data can't cover gas costs
+# since they are retryable.
+return available_balance(tx, asset_id) >= (unavailable_balance(tx, asset_id) + sum_data_messages(tx, asset_id))
 ```
 
 ### Valid Signatures
@@ -173,7 +178,7 @@ If `tx.scriptLength > 0`, the script must be executed. For each asset ID `asset_
 
 ```py
 freeBalance[asset_id] = available_balance(tx, asset_id) - unavailable_balance(tx, asset_id)
-messageBalance = message_balance(tx, 0)
+messageBalance = sum_data_messages(tx, 0)
 ```
 
 Once the free balances are computed, the [script is executed](../vm/index.md#script-execution). After execution, the following is extracted:

--- a/src/protocol/tx_validity.md
+++ b/src/protocol/tx_validity.md
@@ -137,9 +137,9 @@ def unavailable_balance(tx, asset_id) -> int:
         return sentBalance + feeBalance
     return sentBalance
 
-# sum_data_messages is not included in the unavailable_balance since it is spendable as long as there is enough
-# base asset amount to cover gas costs without using data messages. Messages containing data can't cover gas costs
-# since they are retryable.
+# The sum_data_messages total is not included in the unavailable_balance since it is spendable as long as there 
+# is enough base asset amount to cover gas costs without using data messages. Messages containing data can't
+# cover gas costs since they are retryable.
 return available_balance(tx, asset_id) >= (unavailable_balance(tx, asset_id) + sum_data_messages(tx, asset_id))
 ```
 

--- a/src/vm/index.md
+++ b/src/vm/index.md
@@ -101,7 +101,7 @@ There are 3 _contexts_ in the FuelVM: [predicates](#predicate-verification), [sc
 
 ## Predicate Verification
 
-For any input of type [`InputType.Coin`](../protocol/tx_format/index.md), a non-zero `predicateLength` field means the UTXO being spent is a [P2SH](https://en.bitcoinwiki.org/wiki/P2SH) rather than a [P2PKH](https://en.bitcoinwiki.org/wiki/Pay-to-Pubkey_Hash) output.
+For any input of type [`InputType.Coin`](../protocol/tx_format/input.md#inputcoin) or [`InputType.Message`](../protocol/tx_format/input.md#inputmessage), a non-zero `predicateLength` field means the UTXO being spent is a [P2SH](https://en.bitcoinwiki.org/wiki/P2SH) rather than a [P2PKH](https://en.bitcoinwiki.org/wiki/Pay-to-Pubkey_Hash) output.
 
 For each such input in the transaction, the VM is [initialized](#vm-initialization), then:
 


### PR DESCRIPTION
- Keeps messages and coins separated. Reusing fields like UtxoID for message ID is semantically confusing and bloats the serialization payload. It also misses fields from regular messages such as `nonce` and `sender`.
- Updated the freeBalance calculation so that amounts from messages containing data are actually usable within the script and get returned as change.
