### PR TITLE
Reserve undefined flags, and panic if setting them is attempted

### DIFF
--- a/src/vm/index.md
+++ b/src/vm/index.md
@@ -67,6 +67,8 @@ Persistent state (i.e. storage) is a key-value store with 32-byte keys and 32-by
 | `0x01` | `F_UNSAFEMATH` | If bit is set, safe arithmetic and logic is disabled. |
 | `0x02` | `F_WRAPPING`   | If bit is set, wrapping does not cause panic.         |
 
+All other flags are reserved, any must be set to zero.
+
 ## Instruction Set
 
 A complete instruction set of the Fuel VM is documented in [the following page](./instruction_set.md).

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -1725,6 +1725,10 @@ All these instructions advance the program counter `$pc` by `4` after performing
 | Encoding    | `0x00 rA - - -`       |
 | Notes       |                       |
 
+Panic if:
+
+- Any reserved flags are set
+
 ### GM: Get metadata
 
 |             |                           |


### PR DESCRIPTION
As per discussion with @adlerjohn earlier today, setting undefined flags shouldn't be allowed.