### PR TITLE
Add cname for gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,4 +26,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book
           destination_dir: master
+          cname: specs.fuel.network
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
makes specs navigable from specs.fuel.network