### PR TITLE
Make `$hp` point to immediately after usable memory.

### DIFF
--- a/src/vm/index.md
+++ b/src/vm/index.md
@@ -35,24 +35,24 @@ FuelVM instructions are exactly 32 bits (4 bytes) wide and comprise of a combina
 
 Of the 64 registers (6-bit register address space), the first `16` are reserved:
 
-| value  | register | name                | description                                                                   |
-|--------|----------|---------------------|-------------------------------------------------------------------------------|
-| `0x00` | `$zero`  | zero                | Contains zero (`0`), for convenience.                                         |
-| `0x01` | `$one`   | one                 | Contains one (`1`), for convenience.                                          |
-| `0x02` | `$of`    | overflow            | Contains overflow/underflow of addition, subtraction, and multiplication.     |
-| `0x03` | `$pc`    | program counter     | The program counter. Memory address of the current instruction.               |
-| `0x04` | `$ssp`   | stack start pointer | Memory address of bottom of current writable stack area.                      |
-| `0x05` | `$sp`    | stack pointer       | Memory address on top of current writable stack area (points to free memory). |
-| `0x06` | `$fp`    | frame pointer       | Memory address of beginning of current call frame.                            |
-| `0x07` | `$hp`    | heap pointer        | Memory address below the current bottom of the heap (points to free memory).  |
-| `0x08` | `$err`   | error               | Error codes for particular operations.                                        |
-| `0x09` | `$ggas`  | global gas          | Remaining gas globally.                                                       |
-| `0x0A` | `$cgas`  | context gas         | Remaining gas in the context.                                                 |
-| `0x0B` | `$bal`   | balance             | Received balance for this context.                                            |
-| `0x0C` | `$is`    | instrs start        | Pointer to the start of the currently-executing code.                         |
-| `0x0D` | `$ret`   | return value        | Return value or pointer.                                                      |
-| `0x0E` | `$retl`  | return length       | Return value length in bytes.                                                 |
-| `0x0F` | `$flag`  | flags               | Flags register.                                                               |
+| value  | register | name                | description                                                                      |
+|--------|----------|---------------------|----------------------------------------------------------------------------------|
+| `0x00` | `$zero`  | zero                | Contains zero (`0`), for convenience.                                            |
+| `0x01` | `$one`   | one                 | Contains one (`1`), for convenience.                                             |
+| `0x02` | `$of`    | overflow            | Contains overflow/underflow of addition, subtraction, and multiplication.        |
+| `0x03` | `$pc`    | program counter     | The program counter. Memory address of the current instruction.                  |
+| `0x04` | `$ssp`   | stack start pointer | Memory address of bottom of current writable stack area.                         |
+| `0x05` | `$sp`    | stack pointer       | Memory address on top of current writable stack area (points to free memory).    |
+| `0x06` | `$fp`    | frame pointer       | Memory address of beginning of current call frame.                               |
+| `0x07` | `$hp`    | heap pointer        | Memory address below the current bottom of the heap (points to used/oob memory). |
+| `0x08` | `$err`   | error               | Error codes for particular operations.                                           |
+| `0x09` | `$ggas`  | global gas          | Remaining gas globally.                                                          |
+| `0x0A` | `$cgas`  | context gas         | Remaining gas in the context.                                                    |
+| `0x0B` | `$bal`   | balance             | Received balance for this context.                                               |
+| `0x0C` | `$is`    | instrs start        | Pointer to the start of the currently-executing code.                            |
+| `0x0D` | `$ret`   | return value        | Return value or pointer.                                                         |
+| `0x0E` | `$retl`  | return length       | Return value length in bytes.                                                    |
+| `0x0F` | `$flag`  | flags               | Flags register.                                                                  |
 
 Integers are represented in [big-endian](https://en.wikipedia.org/wiki/Endianness) format, and all operations are unsigned. Boolean `false` is `0` and Boolean `true` is `1`.
 

--- a/src/vm/index.md
+++ b/src/vm/index.md
@@ -90,7 +90,7 @@ Then the following registers are initialized (without explicit initialization, a
 
 1. `$ssp = 32 + MAX_INPUTS*(32+8) + size(tx))`: the writable stack area starts immediately after the serialized transaction in memory (see above).
 1. `$sp = $ssp`: writable stack area is empty to start.
-1. `$hp = VM_MAX_RAM - 1`: the heap area begins at the top and is empty to start.
+1. `$hp = VM_MAX_RAM`: the heap area begins at the top and is empty to start.
 
 ## Contexts
 
@@ -162,9 +162,9 @@ Whenever memory is written to (i.e. with [`SB`](./instruction_set.md#sb-store-by
 If the context is external, the owned memory range is:
 
 1. `[$ssp, $sp)`: the writable stack area.
-1. `($hp, VM_MAX_RAM - 1]`: the heap area allocated by this script or predicate.
+1. `($hp - 1, VM_MAX_RAM - 1]`: the heap area allocated by this script or predicate.
 
 If the context is internal, the owned memory range for a call frame is:
 
 1. `[$ssp, $sp)`: the writable stack area of the call frame.
-1. `($hp, $fp->$hp]`: the heap area allocated by this call frame.
+1. `($hp - 1, $fp->$hp - 1]`: the heap area allocated by this call frame.

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -804,8 +804,8 @@ All these instructions advance the program counter `$pc` by `4` after performing
 
 Panic if:
 
-- `$hp - $rA` underflows
-- `$hp - $rA < $sp`
+- `$hp - $rA - 1` underflows
+- `$hp - $rA - 1 < $sp`
 
 ### CFEI: Extend call frame immediate
 
@@ -820,7 +820,7 @@ Panic if:
 Panic if:
 
 - `$sp + imm` overflows
-- `$sp + imm > $hp`
+- `$sp + imm > $hp - 1`
 
 ### CFSI: Shrink call frame immediate
 
@@ -1223,7 +1223,7 @@ Panic if:
 - `$rA + 32` overflows
 - `$ssp + $rC > VM_MAX_RAM`
 - `$rA + 32 > VM_MAX_RAM`
-- `$ssp + $rC > $hp`
+- `$ssp + $rC > $hp - 1`
 - `$rC > CONTRACT_MAX_SIZE`
 - `$rC > MEM_MAX_ACCESS_SIZE`
 - Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`


### PR DESCRIPTION
Fixes #322