### PR TITLE
Remove the `messageId` field from the MessageOut Receipt

### DIFF
--- a/src/protocol/abi/json_abi_format.md
+++ b/src/protocol/abi/json_abi_format.md
@@ -60,7 +60,6 @@ The ABI of a contract is represented as a JSON object containing the following p
       - `"type"`: the _type declaration_ ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
 - `"messagesTypes"`: an array describing all instances of [`smo`](../../vm/instruction_set.md#smo-send-message-to-output) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
-  - `"messageId"`: a unique integer ID. The [`smo`](../../vm/instruction_set.md#smo-send-message-to-output) instruction must set the first word of the message data to that ID.
   - `"messageDataType"`: a _type application_ represented as a JSON object that contains the following properties:
     - `"type"`: the _type declaration_ ID of the type of the message data being sent.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the message data being sent, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:

--- a/src/protocol/abi/receipts.md
+++ b/src/protocol/abi/receipts.md
@@ -255,7 +255,6 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 ## MessageOut Receipt
 
 - `type`: `MessageOut`.
-- `messageID`: Hexadecimal string representation of the 256-bit (32-byte) message ID as described [here](../id/utxo.md#message-id).
 - `sender`: Hexadecimal string representation of the 256-bit (32-byte) address of the message sender: `MEM[$fp, 32]`.
 - `recipient`: Hexadecimal string representation of the 256-bit (32-byte) address of the message recipient: `MEM[$rA, 32]`.
 - `amount`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$rD`.
@@ -267,7 +266,6 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 ```json
 {
   "type": "MessageOut",
-  "messageID": "0x39150017c9e38e5e280432d546fae345d6ce6d8fe4710162c2e3a95a6faff051",
   "sender": "0x38e5e280432d546fae345d6ce6d8fe4710162c2e3a95a6faff05139150017c9e",
   "recipient": "0x4710162c2e3a95a6faff05139150017c9e38e5e280432d546fae345d6ce6d8fe",
   "amount": "0xe6d8fe4710162c2e",

--- a/src/protocol/block_header.md
+++ b/src/protocol/block_header.md
@@ -4,10 +4,10 @@
 
 The application header is a network-agnostic block header. Different [networks](../network/index.md) may wrap the application header in a consensus header, depending on their consensus protocol.
 
-name                    | type       | description
-------------------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------
-`da_height`             | `uint64`   | Height of the data availability layer up to which (inclusive) input messages are processed.
-`txCount`               | `uint64`   | Number of [transaction](./tx_format/transaction.md)s in this block.
-`message_receipt_count` | `uint64`   | Number of [output message](../protocol/abi/receipts.md#messageout_receipt)s in this block.
-`txRoot`                | `byte[32]` | [Merkle root](./cryptographic_primitives.md#binary-merkle-tree) of [transaction](./tx_format/transaction.md)s in this block.
-`message_receipt_root`  | `byte[32]` | [Merkle root](./cryptographic_primitives.md#binary-merkle-tree) of [output message](../protocol/abi/receipts.md#messageout_receipt)s in this block.
+| name                    | type       | description                                                                                                                                                                                |
+|-------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `da_height`             | `uint64`   | Height of the data availability layer up to which (inclusive) input messages are processed.                                                                                                |
+| `txCount`               | `uint64`   | Number of [transaction](./tx_format/transaction.md)s in this block.                                                                                                                        |
+| `message_receipt_count` | `uint64`   | Number of [output message](../protocol/abi/receipts.md#messageout-receipt)s in this block.                                                                                                 |
+| `txRoot`                | `byte[32]` | [Merkle root](./cryptographic_primitives.md#binary-merkle-tree) of [transaction](./tx_format/transaction.md)s in this block.                                                               |
+|  `message_receipt_root` | `byte[32]` | [Merkle root](./cryptographic_primitives.md#binary-merkle-tree) of [output message](../protocol/abi/receipts.md#messageout-receipt)s [`messageId`](./id/utxo.md#message-id) in this block. |

--- a/src/protocol/cryptographic_primitives.md
+++ b/src/protocol/cryptographic_primitives.md
@@ -21,7 +21,7 @@ A specification for the Binary Merkle Tree is [here](https://github.com/celestia
 
 ### Binary Merkle Sum Tree
 
-The Binary Merkle Sum Tree is an extension of the tree defined in [RFC-6962](https://tools.ietf.org/html/rfc6962).
+The Binary Merkle Sum Tree is an extension of the tree defined in [RFC-6962](https://www.rfc-editor.org/rfc/rfc9162).
 
 The root pair `(fee, digest)` of an empty tree is:
 
@@ -55,7 +55,7 @@ Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1
 
 Public keys are encoded in uncompressed form, as the concatenation of the `x` and `y` values. No prefix is needed to distinguish between encoding schemes as this is the only encoding supported.
 
-Deterministic signatures ([RFC-6979](https://tools.ietf.org/rfc/rfc6979.txt)) should be used when signing, but this is not enforced at the protocol level as it cannot be.
+Deterministic signatures ([RFC-6979](https://www.rfc-editor.org/rfc/rfc6979)) should be used when signing, but this is not enforced at the protocol level as it cannot be.
 
 Signatures are represented as the `r` and `s` (each 32 bytes), and `v` (1-bit) values of the signature. `r` and `s` take on their usual meaning (see: [SEC 1, 4.1.3 Signing Operation](https://www.secg.org/sec1-v2.pdf)), while `v` is used for recovering the public key from a signature more quickly (see: [SEC 1, 4.1.6 Public Key Recovery Operation](https://www.secg.org/sec1-v2.pdf)). Only low-`s` values in signatures are valid (i.e. `s <= secp256k1.n//2`); `s` can be replaced with `-s mod secp256k1.n` during the signing process if it is high. Given this, the first bit of `s` will always be `0`, and can be used to store the 1-bit `v` value.
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -1389,14 +1389,14 @@ Cease VM execution and revert script effects. After a revert:
 
 ### SMO: Send message out
 
-|             |                                                                                                                  |
-|-------------|------------------------------------------------------------------------------------------------------------------|
-| Description | Send a message to recipient address `MEM[$rA, 32]` with message data `MEM[$rB, $rC]` and `$rD` base asset coins. |
-| Operation   | ```outputmessage(MEM[$fp, 32], MEM[$rA, 32], MEM[$rB, $rC], $rD);```                                             |
-| Syntax      | `smo $rA, $rB, $rC, $rD`                                                                                         |
-| Encoding    | `0x00 rA rB rC rD`                                                                                               |
-| Effects     | Output message                                                                                                   |
-| Notes       |                                                                                                                  |
+|             |                                                                                                                                                               |
+|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Description | Send a message to recipient address `MEM[$rA, 32]` from the `MEM[$fp, 32]` sender with message data `MEM[$rB, $rC]` and the `$rD` amount of base asset coins. |
+| Operation   | ```outputmessage(MEM[$fp, 32], MEM[$rA, 32], MEM[$rB, $rC], $rD);```                                                                                          |
+| Syntax      | `smo $rA, $rB, $rC, $rD`                                                                                                                                      |
+| Encoding    | `0x00 rA rB rC rD`                                                                                                                                            |
+| Effects     | Output message                                                                                                                                                |
+| Notes       |                                                                                                                                                               |
 
 Given helper `balanceOfStart(asset_id: byte[32]) -> uint32` which returns the memory address of the remaining free balance of `asset_id`, or panics if `asset_id` has no free balance remaining.
 
@@ -1416,7 +1416,6 @@ Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
 | name        | type          | description                                                                  |
 |-------------|---------------|------------------------------------------------------------------------------|
 | `type`      | `ReceiptType` | `ReceiptType.MessageOut`                                                     |
-| `messageID` | `byte[32]`    | The messageID as described [here](../protocol/id/utxo.md#message-id).        |
 | `sender`    | `byte[32]`    | The address of the message sender: `MEM[$fp, 32]`.                           |
 | `recipient` | `byte[32]`    | The address of the message recipient: `MEM[$rA, 32]`.                        |
 | `amount`    | `uint64`      | Amount of base asset coins sent with message: `$rD`.                         |
@@ -1425,7 +1424,6 @@ Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
 | `digest`    | `byte[32]`    | [Hash](#s256-sha-2-256) of `MEM[$rB, $rC]`.                                  |
 
 In an external context, decrease `MEM[balanceOfStart(0), 8]` by `$rD`. In an internal context, decrease asset ID 0 balance of output with contract ID `MEM[$fp, 32]` by `$rD`. This modifies the `balanceRoot` field of the appropriate contract that had its' funds deducted.
-`messageID` is added to the MessageReceipts Merkle tree as part of block header.
 
 ### SCWQ: State clear sequential 32 byte slots
 


### PR DESCRIPTION
This follow-up PR removes the `MessageId` from the receipt. Previously we removed it from the `Input` in the https://github.com/FuelLabs/fuel-specs/pull/443