### PR TITLE
Document the panic conditions of logd

### DIFF
--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -1282,6 +1282,12 @@ Append a receipt to the list of receipts, modifying `tx.receiptsRoot`:
 
 Logs the memory range `MEM[$rC, $rD]`.
 
+Panics if:
+
+- `$rC + $rD` overflows
+- `$rA + $rD > VM_MAX_RAN`
+- `$rD > MEM_MAX_ACCESS_SIZE`
+
 ### MINT: Mint new coins
 
 |             |                                                      |


### PR DESCRIPTION
Accessing invalid memory regions panics, but this was not documented.