### PR TITLE
Make `Nonce` as 32 bytes array

### DIFF
--- a/src/protocol/tx_format/input.md
+++ b/src/protocol/tx_format/input.md
@@ -82,20 +82,20 @@ Transaction is invalid if:
 
 ## InputMessage
 
-| name                  | type         | description                                             |
-|-----------------------|--------------|---------------------------------------------------------|
-| `sender`              | `byte[32]`   | The address of the message sender.                      |
-| `recipient`           | `byte[32]`   | The address or predicate root of the message recipient. |
-| `amount`              | `uint64`     | Amount of base asset coins sent with message.           |
-| `nonce`               | `uint64`     | The message nonce.                                      |
-| `witnessIndex`        | `uint8`      | Index of witness that authorizes spending the coin.     |
-| `dataLength`          | `uint16`     | Length of message data, in bytes.                       |
-| `predicateLength`     | `uint16`     | Length of predicate, in instructions.                   |
-| `predicateDataLength` | `uint16`     | Length of predicate input data, in bytes.               |
-| `data`                | `byte[]`     | The message data.                                       |
-| `predicate`           | `byte[]`     | Predicate bytecode.                                     |
-| `predicateData`       | `byte[]`     | Predicate input data (parameters).                      |
-| `predicateGasUsed`    | `uint64`     | Gas used by predicate execution.                        |
+| name                  | type       | description                                             |
+|-----------------------|------------|---------------------------------------------------------|
+| `sender`              | `byte[32]` | The address of the message sender.                      |
+| `recipient`           | `byte[32]` | The address or predicate root of the message recipient. |
+| `amount`              | `uint64`   | Amount of base asset coins sent with message.           |
+| `nonce`               | `byte[32]` | The message nonce.                                      |
+| `witnessIndex`        | `uint8`    | Index of witness that authorizes spending the coin.     |
+| `dataLength`          | `uint16`   | Length of message data, in bytes.                       |
+| `predicateLength`     | `uint16`   | Length of predicate, in instructions.                   |
+| `predicateDataLength` | `uint16`   | Length of predicate input data, in bytes.               |
+| `data`                | `byte[]`   | The message data.                                       |
+| `predicate`           | `byte[]`   | Predicate bytecode.                                     |
+| `predicateData`       | `byte[]`   | Predicate input data (parameters).                      |
+| `predicateGasUsed`    | `uint64`   | Gas used by predicate execution.                        |
 
 Given helper `len()` that returns the number of bytes of a field.
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -1835,7 +1835,7 @@ Get [fields from the transaction](../protocol/tx_format/transaction.md).
 | `GTF_INPUT_MESSAGE_SENDER`                | `0x115` | Memory address of `tx.inputs[$rB].sender`        |
 | `GTF_INPUT_MESSAGE_RECIPIENT`             | `0x116` | Memory address of `tx.inputs[$rB].recipient`     |
 | `GTF_INPUT_MESSAGE_AMOUNT`                | `0x117` | `tx.inputs[$rB].amount`                          |
-| `GTF_INPUT_MESSAGE_NONCE`                 | `0x118` | `tx.inputs[$rB].nonce`                           |
+| `GTF_INPUT_MESSAGE_NONCE`                 | `0x118` | Memory address of `tx.inputs[$rB].nonce`         |
 | `GTF_INPUT_MESSAGE_WITNESS_INDEX`         | `0x119` | `tx.inputs[$rB].witnessIndex`                    |
 | `GTF_INPUT_MESSAGE_DATA_LENGTH`           | `0x11A` | `tx.inputs[$rB].dataLength`                      |
 | `GTF_INPUT_MESSAGE_PREDICATE_LENGTH`      | `0x11B` | `tx.inputs[$rB].predicateLength`                 |


### PR DESCRIPTION
The specs say that the `Nonce` is a 32 bytes array but the current code uses `Word`. In the follow-up PR in `fuel-vm` we will replace `Word` with a 32-byte array.