### PR TITLE
Remove nested call limit

### DIFF
--- a/src/protocol/tx_format/constants.md
+++ b/src/protocol/tx_format/constants.md
@@ -16,4 +16,3 @@
 | `MAX_STORAGE_SLOTS`         | `uint16` | `255`           | Maximum number of initial storage slots.      |
 | `MAX_WITNESSES`             | `uint64` | `16`            | Maximum number of witnesses.                  |
 | `CHAIN_ID`                  | `uint64` |                 | A unique per-chain identifier.                |
-| `MAX_NESTED_CALLS`          | `uint64` | `64`            | Maximum number of nested contract calls.      |

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -1124,7 +1124,6 @@ Panic if:
 - Reading past `MEM[VM_MAX_RAM - 1]`
 - In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]), 8]`
 - In an internal context, if `$rB` is greater than the balance of asset ID `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
-- If there would be more than `MAX_NESTED_CALLS` levels of nested calls
 
 Register `$rA` is a memory address from which the following fields are set (word-aligned):
 


### PR DESCRIPTION
FuelVM now supports unlimited nested calls, so this limit is removed.

See  https://github.com/FuelLabs/fuel-vm/pull/399