### PR TITLE
Update gas initialization for predicate estimation

### DIFF
--- a/src/vm/index.md
+++ b/src/vm/index.md
@@ -109,7 +109,7 @@ For any input of type [`InputType.Coin`](../protocol/tx_format/index.md) or [`In
 For each such input in the transaction, the VM is [initialized](#vm-initialization), then:
 
 1. `$pc` and `$is` are set to the start of the input's `predicate` field.
-1. `$ggas` and `$cgas` are set to `tx.gasLimit`.
+1. `$ggas` and `$cgas` are set to the minimum of `tx.gasLimit` or `MAX_GAS_PER_PREDICATE`.
 
 Predicate estimation will fail if gas is exhausted during execution.
 


### PR DESCRIPTION
Predicates previously used the tx.gasLimit for initialization but could never be more than MAX_GAS_PER_PREDICATE so they should also be initialized to that value if tx.gasLimit is greater than MAX_GAS_PER_PREDICATE. 