### PR TITLE
increase code root merkle leaf size to 16KiB

### DIFF
--- a/src/protocol/id/contract.md
+++ b/src/protocol/id/contract.md
@@ -1,3 +1,9 @@
 # Contract ID
 
-For a transaction of type `TransactionType.Create`, `tx`, the contract ID is `sha256(0x4655454C ++ tx.data.salt ++ root(tx.data.witnesses[bytecodeWitnessIndex].data) ++ root_smt(tx.storageSlots))`, where `root` is the Merkle root of [the binary Merkle tree](../cryptographic_primitives.md#binary-merkle-tree) with each leaf being an 8-byte word of two instructions, and `root_smt` is the [Sparse Merkle tree](../cryptographic_primitives.md#sparse-merkle-tree) root of the provided key-value pairs. If the bytecode is not a multiple of 8 bytes (i.e. if there are an odd number of instructions), the last instruction is padded with 4-byte zero.
+For a transaction of type `TransactionType.Create`, `tx`, the contract ID is 
+`sha256(0x4655454C ++ tx.data.salt ++ root(tx.data.witnesses[bytecodeWitnessIndex].data) ++ root_smt(tx.storageSlots))`, 
+where `root` is the Merkle root of [the binary Merkle tree](../cryptographic_primitives.md#binary-merkle-tree) with 
+each leaf being 16KiB of instructions, and `root_smt` is the 
+[Sparse Merkle tree](../cryptographic_primitives.md#sparse-merkle-tree) root of the provided key-value pairs. 
+If the bytecode is not a multiple of 16 KiB, the final leaf should be zero-padded rounding up to the nearest multiple
+of 8 bytes.

--- a/src/protocol/id/contract.md
+++ b/src/protocol/id/contract.md
@@ -1,9 +1,9 @@
 # Contract ID
 
-For a transaction of type `TransactionType.Create`, `tx`, the contract ID is 
-`sha256(0x4655454C ++ tx.data.salt ++ root(tx.data.witnesses[bytecodeWitnessIndex].data) ++ root_smt(tx.storageSlots))`, 
-where `root` is the Merkle root of [the binary Merkle tree](../cryptographic_primitives.md#binary-merkle-tree) with 
-each leaf being 16KiB of instructions, and `root_smt` is the 
-[Sparse Merkle tree](../cryptographic_primitives.md#sparse-merkle-tree) root of the provided key-value pairs. 
+For a transaction of type `TransactionType.Create`, `tx`, the contract ID is
+`sha256(0x4655454C ++ tx.data.salt ++ root(tx.data.witnesses[bytecodeWitnessIndex].data) ++ root_smt(tx.storageSlots))`,
+where `root` is the Merkle root of [the binary Merkle tree](../cryptographic_primitives.md#binary-merkle-tree) with
+each leaf being 16KiB of instructions, and `root_smt` is the
+[Sparse Merkle tree](../cryptographic_primitives.md#sparse-merkle-tree) root of the provided key-value pairs.
 If the bytecode is not a multiple of 16 KiB, the final leaf should be zero-padded rounding up to the nearest multiple
 of 8 bytes.

--- a/src/protocol/id/predicate.md
+++ b/src/protocol/id/predicate.md
@@ -2,6 +2,5 @@
 
 For an input of type `InputType.Coin` or `InputType.Message`, `input`, the predicate owner is calculated as:
 `sha256(0x4655454C ++ CHAIN_ID ++ root(input.predicate))`, where `root` is the Merkle root of
-[the binary Merkle tree](../cryptographic_primitives.md#binary-merkle-tree) with each leaf being an 8-byte word of
-two instructions. If the bytecode is not a multiple of 8 bytes (i.e. if there are an odd number of instructions),
-the last instruction is padded with 4-byte zero.
+[the binary Merkle tree](../cryptographic_primitives.md#binary-merkle-tree) each leaf being 16KiB of instructions.
+If the bytecode is not a multiple of 16 KiB, the final leaf should be zero-padded rounding up to the nearest multiple of 8 bytes.


### PR DESCRIPTION
Calculating the merkle root of across every instruction pair is turning out to be quite cost prohibitive, as noted in this issue: https://github.com/FuelLabs/fuel-vm/issues/385

Increasing the leaf size when computing a code root drastically reduces the sha256 overhead. I assume the original design was chosen because 8 bytes is the standard word size of the EVM, making it easier to pass into a merkle proof function. 

Increasing the leaf size leads to >30x performance improvement on the execution layer. Fraud challenges are crypto-economically guaranteed to happen infrequently. So it seems worthwhile to increase the fraud proof cost in the worst case in exchange for substantially improving the happy path of regular transaction execution.

This needs the review of a solidity SME to determine if this is feasible with our current BMT solidity implementation and what the L1 cost would be of increasing the leaf size to 16KiB. My intuition tells me this seems like it should be a non-breaking change to our solidity libraries, as the proof set itself wouldn't need to change. My main question is if the EVM is capable of a sha256 on 16KiB of data, which would allow the leaf element in the proof set to be associated with the correct chunk of bytecode.

I also made a benchmarking framework to experiment with various leaf sizes, making it easy to verify the improvement due to leaf size increases: https://github.com/Voxelot/merkle-bench