### PR TITLE
clarify the description of the coinbase instruction

### DIFF
--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -67,7 +67,7 @@
   - [BHSH: Block hash](#bhsh-block-hash)
   - [BURN: Burn existing coins](#burn-burn-existing-coins)
   - [CALL: Call contract](#call-call-contract)
-  - [CB: Block proposer address](#cb-block-proposer-address)
+  - [CB: Coinbase address](#cb-coinbase-address)
   - [CCP: Code copy](#ccp-code-copy)
   - [CROO: Code Merkle root](#croo-code-merkle-root)
   - [CSIZ: Code size](#csiz-code-size)
@@ -1252,15 +1252,15 @@ A [call frame](./index.md#call-frames) is pushed at `$sp`. In addition to fillin
 
 This modifies the `balanceRoot` field of the appropriate output(s).
 
-### CB: Block proposer address
+### CB: Coinbase address
 
-|             |                                  |
-|-------------|----------------------------------|
-| Description | Get block proposer address.      |
-| Operation   | ```MEM[$rA, 32] = coinbase();``` |
-| Syntax      | `cb $rA`                         |
-| Encoding    | `0x00 rA - - -`                  |
-| Notes       |                                  |
+|             |                                                                                                                   |
+|-------------|-------------------------------------------------------------------------------------------------------------------|
+| Description | Get the [coinbase address](./../protocol/tx_validity.md#coinbase-transaction) associated with the block proposer. |
+| Operation   | ```MEM[$rA, 32] = coinbase();```                                                                                  |
+| Syntax      | `cb $rA`                                                                                                          |
+| Encoding    | `0x00 rA - - -`                                                                                                   |
+| Notes       |                                                                                                                   |
 
 Panic if:
 


### PR DESCRIPTION
The previous description was somewhat ambiguous about whether the `CB` opcode returns the address for the block producer or it's coinbase address (which can be a distinct cold wallet for collecting fees).