### PR TITLE
Wideint instructions

### DIFF
--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -688,7 +688,7 @@ Panic if:
 |             |                                                                                       |
 |-------------|---------------------------------------------------------------------------------------|
 | Description | Compare or examine two 128-bit integers using selected mode                           |
-| Operation   | `b = mem[$rB,16]`<br>;`c = indirect?mem[$rC,16]:$rC;`<br>`$rA = cmp_op(b,c);`         |
+| Operation   | `b = mem[$rB,16];`<br>`c = indirect?mem[$rC,16]:$rC;`<br>`$rA = cmp_op(b,c);`         |
 | Syntax      | `wdcm $rA, $rB, $rC, imm`                                                             |
 | Encoding    | `0x00 rA rB rC i`                                                                     |
 | Notes       |                                                                                       |
@@ -730,7 +730,7 @@ Panic if:
 |             |                                                                                       |
 |-------------|---------------------------------------------------------------------------------------|
 | Description | Compare or examine two 256-bit integers using selected mode                           |
-| Operation   | `b = mem[$rB,32]`<br>;`c = indirect?mem[$rC,32]:$rC;`<br>`$rA = cmp_op(b,c);`         |
+| Operation   | `b = mem[$rB,32];`<br>`c = indirect?mem[$rC,32]:$rC;`<br>`$rA = cmp_op(b,c);`         |
 | Syntax      | `wqcm $rA, $rB, $rC, imm`                                                             |
 | Encoding    | `0x00 rA rB rC i`                                                                     |
 | Notes       |                                                                                       |

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -705,7 +705,7 @@ Then the actual operation that's performed:
 1     | ne   | Inequality (`!=`)
 2     | lt   | Less than (`<`)
 3     | gt   | Greater than (`>`)
-4     | lte  | Less than or equals (`>=`)
+4     | lte  | Less than or equals (`<=`)
 5     | gte  | Greater than or equals (`>=`)
 6     | lzc  | Leading zero count the lhs argument (`lzcnt`). Discards rhs.
 7     | -    | Reserved and must not be used

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -688,8 +688,8 @@ Then the actual comparison that's performed:
 3     | gt   | Greater than (`>`)
 4     | le   | Less than or equals (`>=`)
 5     | ge   | Greater than or equals (`>=`)
-6     | -    | *Reserved*
-7     | -    | *Reserved*
+6     | -    | Reserved and must not be used
+7     | -    | Reserved and must not be used
 
 Clears `$of` and `$err`.
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -663,7 +663,7 @@ Panic if:
 ### WDCM: 128-bit integer comparison
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Compare two 128-bit integers using selected compare mode                              |
 | Operation   | `b = mem[$rB,16]`<br>;`c = indirect?mem[$rC,16]:$rC;`<br>`$rA = cmp_op(b,c);`         |
 | Syntax      | `wdcm $rA, $rB, $rC, imm`                                                             |
@@ -702,7 +702,7 @@ Panic if:
 ### WQCM: 256-bit integer comparison
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Compare two 256-bit integers using selected compare mode                              |
 | Operation   | `b = mem[$rB,32]`<br>;`c = indirect?mem[$rC,32]:$rC;`<br>`$rA = cmp_op(b,c);`         |
 | Syntax      | `wqcm $rA, $rB, $rC, imm`                                                             |
@@ -719,11 +719,10 @@ Panic if:
 - `$rB + 16` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
 
-
 ### WDOP: Misc 128-bit integer operations
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Perform an ALU operation on two 128-bit integers                                      |
 | Operation   | `b = mem[$rB,16];`<br>`c = indirect?mem[$rC,16]:$rC;`<br>`mem[$rA,16] = op(b,c);`     |
 | Syntax      | `wdop $rA, $rB, $rC, imm`                                                             |
@@ -762,7 +761,7 @@ Panic if:
 ### WQOP: Misc 256-bit integer operations
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Perform an ALU operation on two 256-bit integers                                      |
 | Operation   | `b = mem[$rB,32];`<br>`c = indirect?mem[$rC,32]:$rC;`<br>`mem[$rA,32] = op(b,c);`     |
 | Syntax      | `wqop $rA, $rB, $rC, imm`                                                             |
@@ -782,7 +781,7 @@ Panic if:
 ### WDML: Multiply 128-bit integers
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Perform integer multiplication operation on two 128-bit integers.                     |
 | Operation   | `b=indirect0?mem[$rB,16]:$rB;`<br>`c=indirect1?mem[$rC,16]:$rC;`<br>`mem[$rA,16]=b*c;`|
 | Syntax      | `wdml $rA, $rB, $rC, imm`                                                             |
@@ -810,7 +809,7 @@ Panic if:
 ### WQML: Multiply 128-bit integers
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Perform integer multiplication operation on two 256-bit integers.                     |
 | Operation   | `b=indirect0?mem[$rB,16]:$rB;`<br>`c=indirect1?mem[$rC,16]:$rC;`<br>`mem[$rA,16]=b*c;`|
 | Syntax      | `wqml $rA, $rB, $rC, imm`                                                             |
@@ -832,7 +831,7 @@ Panic if:
 ### WDDV: 128-bit integer division
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Divide a 128-bit integer by another.                                                  |
 | Operation   | `b = mem[$rB,16];`<br>`c = indirect?mem[$rC,16]:$rC;`<br>`mem[$rA,16] = b / c;`       |
 | Syntax      | `wddv $rA, $rB, $rC, imm`                                                             |
@@ -859,7 +858,7 @@ Panic if:
 ### WQDV: 256-bit integer division
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Divide a 256-bit integer by another.                                                  |
 | Operation   | `b = mem[$rB,32];`<br>`c = indirect?mem[$rC,32]:$rC;`<br>`mem[$rA,32] = b / c;`       |
 | Syntax      | `wqdv $rA, $rB, $rC, imm`                                                             |
@@ -881,7 +880,7 @@ Panic if:
 ### WDAM: Modular 128-bit integer addition
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Add two 128-bit integers and compute modulo remainder with arbitrary precision.       |
 | Operation   | `b=mem[$rB,16];`<br>`c=mem[$rC,16];`<br>`d=mem[$rD,16];`<br>`mem[$rA,16] = (b+c)%d;`  |
 | Syntax      | `wdam $rA, $rB, $rC, $rD`                                                             |
@@ -897,11 +896,10 @@ Panic if:
 - `$rC + 16` overflows or `> VM_MAX_RAM`
 - `$rD + 16` overflows or `> VM_MAX_RAM`
 
-
 ### WQAM: Modular 256-bit integer addition
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Add two 256-bit integers and compute modulo remainder with arbitrary precision.       |
 | Operation   | `b=mem[$rB,32];`<br>`c=mem[$rC,32];`<br>`d=mem[$rD,32];`<br>`mem[$rA,32] = (b+c)%d;`  |
 | Syntax      | `wdam $rA, $rB, $rC, $rD`                                                             |
@@ -920,7 +918,7 @@ Panic if:
 ### WDMM: Modular 128-bit integer multiplication
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Multiply two 128-bit integers and compute modulo remainder with arbitrary precision.  |
 | Operation   | `b=mem[$rB,16];`<br>`c=mem[$rC,16];`<br>`d=mem[$rD,16];`<br>`mem[$rA,16] = (b*c)%d;`  |
 | Syntax      | `wdmm $rA, $rB, $rC, $rD`                                                             |
@@ -939,7 +937,7 @@ Panic if:
 ### WQMM: Modular 256-bit integer multiplication
 
 |             |                                                                                       |
-|-------------|---------------------------------------------------------------------------------------| 
+|-------------|---------------------------------------------------------------------------------------|
 | Description | Multiply two 256-bit integers and compute modulo remainder with arbitrary precision.  |
 | Operation   | `b=mem[$rB,32];`<br>`c=mem[$rC,32];`<br>`d=mem[$rD,32];`<br>`mem[$rA,32] = (b*c)%d;`  |
 | Syntax      | `wqmm $rA, $rB, $rC, $rD`                                                             |
@@ -954,7 +952,6 @@ Panic if:
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rC + 32` overflows or `> VM_MAX_RAM`
 - `$rD + 32` overflows or `> VM_MAX_RAM`
-
 
 ### XOR: XOR
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -674,7 +674,7 @@ The six-bit immediate value is used to select operating mode, as follows:
 
 Bits     | Short name | Description
 ---------|------------|-------------
-`...XXX` | `mode`     | Compre mode selection
+`...XXX` | `mode`     | Compare mode selection
 `.XX...` | `reserved` | Reserved and must be zero
 `X.....` | `indirect` | Is rhs operand ($rC) indirect or not
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -716,8 +716,8 @@ Clears `$of` and `$err`.
 Panic if:
 
 - `$rA` is a [reserved register](./index.md#semantics)
-- `$rB + 16` overflows or `> VM_MAX_RAM`
-- `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
+- `$rB + 32` overflows or `> VM_MAX_RAM`
+- `indirect == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
 
 ### WDOP: Misc 128-bit integer operations
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -31,6 +31,19 @@
   - [SRLI: Shift right logical immediate](#srli-shift-right-logical-immediate)
   - [SUB: Subtract](#sub-subtract)
   - [SUBI: Subtract immediate](#subi-subtract-immediate)
+  - [SUBI: Subtract immediate](#subi-subtract-immediate)
+  - [WDCM: 128-bit integer comparison](#wdcm-128-bit-integer-comparison)
+  - [WQCM: 256-bit integer comparison](#wqcm-256-bit-integer-comparison)
+  - [WDOP: Misc 128-bit integer operations](#wdop-misc-128-bit-integer-operations)
+  - [WQOP: Misc 256-bit integer operations](#wqop-misc-256-bit-integer-operations)
+  - [WDML: Multiply 128-bit integers](#wdml-multiply-128-bit-integers)
+  - [WQML: Multiply 128-bit integers](#wqml-multiply-128-bit-integers)
+  - [WDDV: 128-bit integer division](#wddv-128-bit-integer-division)
+  - [WQDV: 256-bit integer division](#wqdv-256-bit-integer-division)
+  - [WDAM: Modular 128-bit integer addition](#wdam-modular-128-bit-integer-addition)
+  - [WQAM: Modular 256-bit integer addition](#wqam-modular-256-bit-integer-addition)
+  - [WDMM: Modular 128-bit integer multiplication](#wdmm-modular-128-bit-integer-multiplication)
+  - [WQMM: Modular 256-bit integer multiplication](#wqmm-modular-256-bit-integer-multiplication)
   - [XOR: XOR](#xor-xor)
   - [XORI: XOR immediate](#xori-xor-immediate)
 - [Control Flow Instructions](#control-flow-instructions)
@@ -646,6 +659,302 @@ Panic if:
 `$of` is assigned the underflow of the operation, as though `$of` is the high byte of a 128-bit register.
 
 `$err` is cleared.
+
+### WDCM: 128-bit integer comparison
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Compare two 128-bit integers using selected compare mode                              |
+| Operation   | `b = mem[$rB,16]`<br>;`c = indirect?mem[$rC,16]:$rC;`<br>`$rA = cmp_op(b,c);`         |
+| Syntax      | `wdcm $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The six-bit immediate value is used to select operating mode, as follows:
+
+Bits     | Short name | Description
+---------|------------|-------------
+`...XXX` | `mode`     | Compre mode selection
+`.XX...` | `reserved` | Reserved and must be zero
+`X.....` | `indirect` | Is rhs operand ($rC) indirect or not
+
+Then the actual comparison that's performed:
+
+`mode`| Name | Description
+------|------|------------
+0     | eq   | Equality (`==`)
+1     | ne   | Inequality (`!=`)
+2     | lt   | Less than (`<`)
+3     | gt   | Greater than (`>`)
+4     | le   | Less than or equals (`>=`)
+5     | ge   | Greater than or equals (`>=`)
+6     | ao   | Sum of the values would overflow
+7     | mo   | Product of the values would overflow
+
+Clears `$of` and `$err`.
+
+Panic if:
+
+- `$rA` is a [reserved register](./index.md#semantics)
+- `$rB + 16` overflows or `> VM_MAX_RAM`
+- `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
+
+### WQCM: 256-bit integer comparison
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Compare two 256-bit integers using selected compare mode                              |
+| Operation   | `b = mem[$rB,32]`<br>;`c = indirect?mem[$rC,32]:$rC;`<br>`$rA = cmp_op(b,c);`         |
+| Syntax      | `wqcm $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The immediate value is interpreted identically to `WDCM`.
+
+Clears `$of` and `$err`.
+
+Panic if:
+
+- `$rA` is a [reserved register](./index.md#semantics)
+- `$rB + 16` overflows or `> VM_MAX_RAM`
+- `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
+
+
+### WDOP: Misc 128-bit integer operations
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Perform an ALU operation on two 128-bit integers                                      |
+| Operation   | `b = mem[$rB,16];`<br>`c = indirect?mem[$rC,16]:$rC;`<br>`mem[$rA,16] = op(b,c);`     |
+| Syntax      | `wdop $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The six-bit immediate value is used to select operating mode, as follows:
+
+Bits     | Short name | Description
+---------|------------|-------------
+`...XXX` | `op`       | Operation selection, see below
+`.XX...` | `reserved` | Reserved and must be zero
+`X.....` | `indirect` | Is rhs operand ($rC) indirect or not
+
+Then the actual operation that's performed:
+
+`op` | Name | Description
+-----|------|------------
+0    | add  | Add
+1    | sub  | Subtract
+2    | not  | Invert bits (discards rhs)
+3    | or   | Bitwise or
+4    | xor  | Bitwise exclusive or
+5    | and  | Bitwise and
+6    | shl  | Shift left
+7    | shr  | Shift right
+
+Operations behave `$of` and `$err` similarly to their 64-bit counterparts.
+
+Panic if:
+
+- The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 16` overflows or `> VM_MAX_RAM`
+- `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
+
+### WQOP: Misc 256-bit integer operations
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Perform an ALU operation on two 256-bit integers                                      |
+| Operation   | `b = mem[$rB,32];`<br>`c = indirect?mem[$rC,32]:$rC;`<br>`mem[$rA,32] = op(b,c);`     |
+| Syntax      | `wqop $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The immediate value is interpreted identically to `WQOP`.
+
+Operations behave `$of` and `$err` similarly to their 64-bit counterparts.
+
+Panic if:
+
+- The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 32` overflows or `> VM_MAX_RAM`
+- `indirect == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
+
+### WDML: Multiply 128-bit integers
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Perform integer multiplication operation on two 128-bit integers.                     |
+| Operation   | `b=indirect0?mem[$rB,16]:$rB;`<br>`c=indirect1?mem[$rC,16]:$rC;`<br>`mem[$rA,16]=b*c;`|
+| Syntax      | `wdml $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The six-bit immediate value is used to select operating mode, as follows:
+
+Bits     | Short name | Description
+---------|------------|-------------
+`..XXXX` | `reserved` | Reserved and must be zero
+`.X....` | `indirect0`| Is lhs operand ($rB) indirect or not
+`X.....` | `indirect1`| Is rhs operand ($rC) indirect or not
+
+`$of` is set to `1` in case of overflow, and cleared otherwise.
+
+`$err` is cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
+- `indirect0 == 1` and `$rB + 16` overflows or `> VM_MAX_RAM`
+- `indirect1 == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
+
+### WQML: Multiply 128-bit integers
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Perform integer multiplication operation on two 256-bit integers.                     |
+| Operation   | `b=indirect0?mem[$rB,16]:$rB;`<br>`c=indirect1?mem[$rC,16]:$rC;`<br>`mem[$rA,16]=b*c;`|
+| Syntax      | `wqml $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The immediate value is interpreted identically to `WDML`.
+
+`$of` is set to `1` in case of overflow, and cleared otherwise.
+
+`$err` is cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
+- `indirect0 == 1` and `$rB + 32` overflows or `> VM_MAX_RAM`
+- `indirect1 == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
+
+### WDDV: 128-bit integer division
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Divide a 128-bit integer by another.                                                  |
+| Operation   | `b = mem[$rB,16];`<br>`c = indirect?mem[$rC,16]:$rC;`<br>`mem[$rA,16] = b / c;`       |
+| Syntax      | `wddv $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The six-bit immediate value is used to select operating mode, as follows:
+
+Bits     | Short name | Description
+---------|------------|-------------
+`.XXXXX` | `reserved` | Reserved and must be zero
+`X.....` | `indirect` | Is rhs operand ($rC) indirect or not
+
+`$of` is cleared.
+
+If the rhs operand is zero, `MEM[$rA, 16]` is cleared and `$err` is set to `true`. Otherwise, `$err` is cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 16` overflows or `> VM_MAX_RAM`
+- `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
+
+### WQDV: 256-bit integer division
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Divide a 256-bit integer by another.                                                  |
+| Operation   | `b = mem[$rB,32];`<br>`c = indirect?mem[$rC,32]:$rC;`<br>`mem[$rA,32] = b / c;`       |
+| Syntax      | `wqdv $rA, $rB, $rC, imm`                                                             |
+| Encoding    | `0x00 rA rB rC i`                                                                     |
+| Notes       |                                                                                       |
+
+The immediate value is interpreted identically to `WDDV`.
+
+`$of` is cleared.
+
+If the rhs operand is zero, `MEM[$rA, 32]` is cleared and `$err` is set to `true`. Otherwise, `$err` is cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 32` overflows or `> VM_MAX_RAM`
+- `indirect == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
+
+### WDAM: Modular 128-bit integer addition
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Add two 128-bit integers and compute modulo remainder with arbitrary precision.       |
+| Operation   | `b=mem[$rB,16];`<br>`c=mem[$rC,16];`<br>`d=mem[$rD,16];`<br>`mem[$rA,16] = (b+c)%d;`  |
+| Syntax      | `wdam $rA, $rB, $rC, $rD`                                                             |
+| Encoding    | `0x00 rA rB rC rD`                                                                    |
+| Notes       |                                                                                       |
+
+`$err` and `$of` are cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 16` overflows or `> VM_MAX_RAM`
+- `$rC + 16` overflows or `> VM_MAX_RAM`
+- `$rD + 16` overflows or `> VM_MAX_RAM`
+
+
+### WQAM: Modular 256-bit integer addition
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Add two 256-bit integers and compute modulo remainder with arbitrary precision.       |
+| Operation   | `b=mem[$rB,32];`<br>`c=mem[$rC,32];`<br>`d=mem[$rD,32];`<br>`mem[$rA,32] = (b+c)%d;`  |
+| Syntax      | `wdam $rA, $rB, $rC, $rD`                                                             |
+| Encoding    | `0x00 rA rB rC rD`                                                                    |
+| Notes       |                                                                                       |
+
+`$err` and `$of` are cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 32` overflows or `> VM_MAX_RAM`
+- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rD + 32` overflows or `> VM_MAX_RAM`
+
+### WDMM: Modular 128-bit integer multiplication
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Multiply two 128-bit integers and compute modulo remainder with arbitrary precision.  |
+| Operation   | `b=mem[$rB,16];`<br>`c=mem[$rC,16];`<br>`d=mem[$rD,16];`<br>`mem[$rA,16] = (b*c)%d;`  |
+| Syntax      | `wdmm $rA, $rB, $rC, $rD`                                                             |
+| Encoding    | `0x00 rA rB rC rD`                                                                    |
+| Notes       |                                                                                       |
+
+`$err` and `$of` are cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 16` overflows or `> VM_MAX_RAM`
+- `$rC + 16` overflows or `> VM_MAX_RAM`
+- `$rD + 16` overflows or `> VM_MAX_RAM`
+
+### WQMM: Modular 256-bit integer multiplication
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------| 
+| Description | Multiply two 256-bit integers and compute modulo remainder with arbitrary precision.  |
+| Operation   | `b=mem[$rB,32];`<br>`c=mem[$rC,32];`<br>`d=mem[$rD,32];`<br>`mem[$rA,32] = (b*c)%d;`  |
+| Syntax      | `wqmm $rA, $rB, $rC, $rD`                                                             |
+| Encoding    | `0x00 rA rB rC rD`                                                                    |
+| Notes       |                                                                                       |
+
+`$err` and `$of` are cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 32` overflows or `> VM_MAX_RAM`
+- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rD + 32` overflows or `> VM_MAX_RAM`
+
 
 ### XOR: XOR
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -895,7 +895,9 @@ Panic if:
 | Encoding    | `0x00 rA rB rC rD`                                                                    |
 | Notes       |                                                                                       |
 
-`$err` and `$of` are cleared.
+`$of` is cleared.
+
+If the rhs operand is zero, `MEM[$rA, 16]` is cleared and `$err` is set to `true`. Otherwise, `$err` is cleared.
 
 Panic if:
 
@@ -914,7 +916,9 @@ Panic if:
 | Encoding    | `0x00 rA rB rC rD`                                                                    |
 | Notes       |                                                                                       |
 
-`$err` and `$of` are cleared.
+`$of` is cleared.
+
+If the rhs operand is zero, `MEM[$rA, 16]` is cleared and `$err` is set to `true`. Otherwise, `$err` is cleared.
 
 Panic if:
 
@@ -933,7 +937,9 @@ Panic if:
 | Encoding    | `0x00 rA rB rC rD`                                                                    |
 | Notes       |                                                                                       |
 
-`$err` and `$of` are cleared.
+`$of` is cleared.
+
+If the rhs operand is zero, `MEM[$rA, 16]` is cleared and `$err` is set to `true`. Otherwise, `$err` is cleared.
 
 Panic if:
 
@@ -952,7 +958,9 @@ Panic if:
 | Encoding    | `0x00 rA rB rC rD`                                                                    |
 | Notes       |                                                                                       |
 
-`$err` and `$of` are cleared.
+`$of` is cleared.
+
+If the rhs operand is zero, `MEM[$rA, 16]` is cleared and `$err` is set to `true`. Otherwise, `$err` is cleared.
 
 Panic if:
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -773,7 +773,7 @@ Then the actual operation that's performed:
 6    | shl  | Shift left (logical)
 7    | shr  | Shift right (logical)
 
-Operations behave `$of` and `$err` similarly to their 64-bit counterparts.
+Operations behave `$of` and `$err` similarly to their 64-bit counterparts, except that `$of` is set to `1` instead of the overflowing part.
 
 Panic if:
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -806,12 +806,12 @@ Panic if:
 - `indirect0 == 1` and `$rB + 16` overflows or `> VM_MAX_RAM`
 - `indirect1 == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
 
-### WQML: Multiply 128-bit integers
+### WQML: Multiply 256-bit integers
 
 |             |                                                                                       |
 |-------------|---------------------------------------------------------------------------------------|
 | Description | Perform integer multiplication operation on two 256-bit integers.                     |
-| Operation   | `b=indirect0?mem[$rB,16]:$rB;`<br>`c=indirect1?mem[$rC,16]:$rC;`<br>`mem[$rA,16]=b*c;`|
+| Operation   | `b=indirect0?mem[$rB,32]:$rB;`<br>`c=indirect1?mem[$rC,32]:$rC;`<br>`mem[$rA,32]=b*c;`|
 | Syntax      | `wqml $rA, $rB, $rC, imm`                                                             |
 | Encoding    | `0x00 rA rB rC i`                                                                     |
 | Notes       |                                                                                       |

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -688,13 +688,14 @@ Then the actual comparison that's performed:
 3     | gt   | Greater than (`>`)
 4     | le   | Less than or equals (`>=`)
 5     | ge   | Greater than or equals (`>=`)
-6     | ao   | Sum of the values would overflow
-7     | mo   | Product of the values would overflow
+6     | -    | *Reserved*
+7     | -    | *Reserved*
 
 Clears `$of` and `$err`.
 
 Panic if:
 
+- A reserved compare mode is given
 - `$rA` is a [reserved register](./index.md#semantics)
 - `$rB + 16` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
@@ -715,6 +716,7 @@ Clears `$of` and `$err`.
 
 Panic if:
 
+- A reserved compare mode is given
 - `$rA` is a [reserved register](./index.md#semantics)
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
@@ -754,6 +756,7 @@ Operations behave `$of` and `$err` similarly to their 64-bit counterparts.
 
 Panic if:
 
+- Reserved bits of the immediate are set
 - The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
 - `$rB + 16` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
@@ -774,6 +777,7 @@ Operations behave `$of` and `$err` similarly to their 64-bit counterparts.
 
 Panic if:
 
+- Reserved bits of the immediate are set
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
@@ -802,6 +806,7 @@ Bits     | Short name | Description
 
 Panic if:
 
+- Reserved bits of the immediate are set
 - The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
 - `indirect0 == 1` and `$rB + 16` overflows or `> VM_MAX_RAM`
 - `indirect1 == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
@@ -824,6 +829,7 @@ The immediate value is interpreted identically to `WDML`.
 
 Panic if:
 
+- Reserved bits of the immediate are set
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
 - `indirect0 == 1` and `$rB + 32` overflows or `> VM_MAX_RAM`
 - `indirect1 == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
@@ -851,6 +857,7 @@ If the rhs operand is zero, `MEM[$rA, 16]` is cleared and `$err` is set to `true
 
 Panic if:
 
+- Reserved bits of the immediate are set
 - The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
 - `$rB + 16` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 16` overflows or `> VM_MAX_RAM`
@@ -873,6 +880,7 @@ If the rhs operand is zero, `MEM[$rA, 32]` is cleared and `$err` is set to `true
 
 Panic if:
 
+- Reserved bits of the immediate are set
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -503,7 +503,7 @@ Panic if:
 |-------------|---------------------------------------------------------------------------------------|
 | Description | Multiplies two registers with arbitrary precision, then divides by a third register.  |
 | Operation   | `a = (b * c) / d;`                                                                    |
-| Syntax      | `wqdv $rA, $rB, $rC, $rD`                                                             |
+| Syntax      | `mldv $rA, $rB, $rC, $rD`                                                             |
 | Encoding    | `0x00 rA rB rC rD`                                                                    |
 | Notes       | Division by zero is treated as division by `1 << 64` instead.                         |
 
@@ -683,7 +683,7 @@ Panic if:
 
 |             |                                                                                       |
 |-------------|---------------------------------------------------------------------------------------|
-| Description | Compare two 128-bit integers using selected compare mode                              |
+| Description | Compare or examine two 128-bit integers using selected mode                           |
 | Operation   | `b = mem[$rB,16]`<br>;`c = indirect?mem[$rC,16]:$rC;`<br>`$rA = cmp_op(b,c);`         |
 | Syntax      | `wdcm $rA, $rB, $rC, imm`                                                             |
 | Encoding    | `0x00 rA rB rC i`                                                                     |
@@ -697,7 +697,7 @@ Bits     | Short name | Description
 `.XX...` | `reserved` | Reserved and must be zero
 `X.....` | `indirect` | Is rhs operand ($rC) indirect or not
 
-Then the actual comparison that's performed:
+Then the actual operation that's performed:
 
 `mode`| Name | Description
 ------|------|------------
@@ -705,10 +705,12 @@ Then the actual comparison that's performed:
 1     | ne   | Inequality (`!=`)
 2     | lt   | Less than (`<`)
 3     | gt   | Greater than (`>`)
-4     | le   | Less than or equals (`>=`)
-5     | ge   | Greater than or equals (`>=`)
-6     | -    | Reserved and must not be used
+4     | lte  | Less than or equals (`>=`)
+5     | gte  | Greater than or equals (`>=`)
+6     | lzc  | Leading zero count the lhs argument (`lzcnt`). Discards rhs.
 7     | -    | Reserved and must not be used
+
+The leading zero count can be used to compute rounded-down log2 of a number using the following formula `TOTAL_BITS - 1 - lzc(n)`. Note that `log2(0)` is undefined, and will lead to integer overflow with this method.
 
 Clears `$of` and `$err`.
 
@@ -723,7 +725,7 @@ Panic if:
 
 |             |                                                                                       |
 |-------------|---------------------------------------------------------------------------------------|
-| Description | Compare two 256-bit integers using selected compare mode                              |
+| Description | Compare or examine two 256-bit integers using selected mode                           |
 | Operation   | `b = mem[$rB,32]`<br>;`c = indirect?mem[$rC,32]:$rC;`<br>`$rA = cmp_op(b,c);`         |
 | Syntax      | `wqcm $rA, $rB, $rC, imm`                                                             |
 | Encoding    | `0x00 rA rB rC i`                                                                     |

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -40,6 +40,8 @@
   - [WQML: Multiply 256-bit integers](#wqml-multiply-256-bit-integers)
   - [WDDV: 128-bit integer division](#wddv-128-bit-integer-division)
   - [WQDV: 256-bit integer division](#wqdv-256-bit-integer-division)
+  - [WDMD: 128-bit integer fused multiply-divide](#wdmd-128-bit-integer-fused-multiply-divide)
+  - [WQMD: 256-bit integer fused multiply-divide](#wqmd-256-bit-integer-fused-multiply-divide)
   - [WDAM: Modular 128-bit integer addition](#wdam-modular-128-bit-integer-addition)
   - [WQAM: Modular 256-bit integer addition](#wqam-modular-256-bit-integer-addition)
   - [WDMM: Modular 128-bit integer multiplication](#wdmm-modular-128-bit-integer-multiplication)
@@ -749,8 +751,8 @@ Then the actual operation that's performed:
 3    | or   | Bitwise or
 4    | xor  | Bitwise exclusive or
 5    | and  | Bitwise and
-6    | shl  | Shift left
-7    | shr  | Shift right
+6    | shl  | Shift left (logical)
+7    | shr  | Shift right (logical)
 
 Operations behave `$of` and `$err` similarly to their 64-bit counterparts.
 
@@ -884,6 +886,52 @@ Panic if:
 - The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `indirect == 1` and `$rC + 32` overflows or `> VM_MAX_RAM`
+
+### WDMD: 128-bit integer fused multiply-divide
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------|
+| Description | Combined multiply-divide of 128-bit integers with arbitrary precision.                |
+| Operation   | `b=mem[$rB,16];`<br>`c=mem[$rC,16];`<br>`d=mem[$rD,16];`<br>`mem[$rA,16]=(b * c) / d;`|
+| Syntax      | `wddv $rA, $rB, $rC, $rD`                                                             |
+| Encoding    | `0x00 rA rB rC rD`                                                                    |
+| Notes       | Division by zero is treated as division by `1 << 128` instead.                        |
+
+If the divisor `MEM[$rA, 16]` is zero, then instead the value is divided by `1 << 128`. This returns the higher half of the 256-bit multiplication result.
+
+If the result of after the division is larger than operand size, `$of` is set to one. Otherwise, `$of` is cleared.
+
+`$err` is cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 16]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 16` overflows or `> VM_MAX_RAM`
+- `$rC + 16` overflows or `> VM_MAX_RAM`
+- `$rD + 16` overflows or `> VM_MAX_RAM`
+
+### WQMD: 256-bit integer fused multiply-divide
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------|
+| Description | Combined multiply-divide of 256-bit integers with arbitrary precision.                |
+| Operation   | `b=mem[$rB,32];`<br>`c=mem[$rC,32];`<br>`d=mem[$rD,32];`<br>`mem[$rA,32]=(b * c) / d;`|
+| Syntax      | `wqdv $rA, $rB, $rC, $rD`                                                             |
+| Encoding    | `0x00 rA rB rC rD`                                                                    |
+| Notes       | Division by zero is treated as division by `1 << 256` instead.                        |
+
+If the divisor `MEM[$rA, 32]` is zero, then instead the value is divided by `1 << 256`. This returns the higher half of the 512-bit multiplication result.
+
+If the result of after the division is larger than operand size, `$of` is set to one. Otherwise, `$of` is cleared.
+
+`$err` is cleared.
+
+Panic if:
+
+- The memory range `MEM[$rA, 32]`  does not pass [ownership check](./index.md#ownership)
+- `$rB + 32` overflows or `> VM_MAX_RAM`
+- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rD + 32` overflows or `> VM_MAX_RAM`
 
 ### WDAM: Modular 128-bit integer addition
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -21,6 +21,7 @@
   - [MROO: Math root](#mroo-math-root)
   - [MUL: Multiply](#mul-multiply)
   - [MULI: Multiply immediate](#muli-multiply-immediate)
+  - [MLDV: Fused multiply-divide](#mldv-fused-multiply-divide)
   - [NOOP: No operation](#noop-no-operation)
   - [NOT: Invert](#not-invert)
   - [OR: OR](#or-or)
@@ -493,6 +494,22 @@ Panic if:
 - `$rA` is a [reserved register](./index.md#semantics)
 
 `$of` is assigned the overflow of the operation.
+
+`$err` is cleared.
+
+### MLDV: Fused multiply-divide
+
+|             |                                                                                       |
+|-------------|---------------------------------------------------------------------------------------|
+| Description | Multiplies two registers with arbitrary precision, then divides by a third register.  |
+| Operation   | `a = (b * c) / d;`                                                                    |
+| Syntax      | `wqdv $rA, $rB, $rC, $rD`                                                             |
+| Encoding    | `0x00 rA rB rC rD`                                                                    |
+| Notes       | Division by zero is treated as division by `1 << 64` instead.                         |
+
+If the divisor (`$rD`) is zero, then instead the value is divided by `1 << 64`. This returns the higher half of the 128-bit multiplication result. This operation never overflows.
+
+If the result of after the division doesn't fit into a register, `$of` is assigned the overflow of the operation. Otherwise, `$of` is cleared.
 
 `$err` is cleared.
 

--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -37,7 +37,7 @@
   - [WDOP: Misc 128-bit integer operations](#wdop-misc-128-bit-integer-operations)
   - [WQOP: Misc 256-bit integer operations](#wqop-misc-256-bit-integer-operations)
   - [WDML: Multiply 128-bit integers](#wdml-multiply-128-bit-integers)
-  - [WQML: Multiply 128-bit integers](#wqml-multiply-128-bit-integers)
+  - [WQML: Multiply 256-bit integers](#wqml-multiply-256-bit-integers)
   - [WDDV: 128-bit integer division](#wddv-128-bit-integer-division)
   - [WQDV: 256-bit integer division](#wqdv-256-bit-integer-division)
   - [WDAM: Modular 128-bit integer addition](#wdam-modular-128-bit-integer-addition)


### PR DESCRIPTION
Progress towards https://github.com/FuelLabs/fuel-specs/issues/478.  Implementation PR: https://github.com/FuelLabs/fuel-vm/pull/424

This PR adds instructions for handling wideint types, specifically memory-stored 128- and 256-bit unsigned integers. The following opcodes are added:

* MLDV - Fused multiply-add of 64bit register values
* WDCM - Compare 128bit integers
* WQCM - Compare 256bit integers
* WDOP - Cheap 128bit operations (add,, sub, shr, shl, not, and, or, xor)
* WQOP - Cheap 256bit operations (add,, sub, shr, shl, not, and, or, xor)
* WDML - Multiply 128bit
* WQML - Multiply 256bit
* WDDV - Divide 128bit
* WQDV - Divide 256bit
* WDMD - Fused multiply-divide 128bit
* WQMD - Fused multiply-divide 256bit
* WDAM - AddMod 128bit
* WQAM - AddMod 256bit
* WDMM - MulMod 128bit
* WQMM - MulMod 256bit

The naming convention is to prefix the operations with their size: `WD` for double-word-sized (128 bit) operations, and `WQ` for quad-word-sized (256 bit) operations.

### Grouped by cost

The operations are grouped to these opcodes so that cost of a signle opcode can be a constant. To avoid polluting the opcode space, several operations are grouped together: W*CM for compare operations and W*OP for arithmetic operations. The actual operation is then selected using the immediate part of the instruction.

Since multiplication and especially division are more expensive than cheap operations behind these groups, they have their own, separate opcodes. Similarly AddMod and MulMod, which require larger precision than the input operations, are grouped separately. A separate modulus instruction is not provided, but AddMod with addition of zero will perform this function with minimal overhead.

### Direct/Indirect arguments

Some of the operations also allow users to select between direct and indirect operands. When a direct operand is selected, instead of reading the wide integer pointed by the register value, the register value itself is zero-extended to full-width value and used as an operand. This reduces the size of many common operations by a couple of instructions. Also, this means that u64 * u64 -> u128 can be done directly.

### What's missing?

Astute reviewers might have already noticed that some operations are missing. 

* exponentation - Can be added if needed, also ExpMod could be added
* logarithm - This can be added if any use cases are found
* nth root (or even square root) - The roots are rather slow to compute, and hopefully never needed. Even the 64bit version was tricky
* Fused opcodes like multiply-add and multiply-divide

### Hopes and dreams

We could support these operations for 64-bit integers as well, and remove current ALU instructions completely. However, I think that we are too committed to backwards compatibility of the current ops even now.
