### PR TITLE
Bitshift should discard overflow

### DIFF
--- a/src/vm/instruction_set.md
+++ b/src/vm/instruction_set.md
@@ -625,9 +625,7 @@ Panic if:
 
 - `$rA` is a [reserved register](./index.md#semantics)
 
-`$of` is assigned the underflow of the operation, as though `$of` is the high byte of a 128-bit register.
-
-`$err` is cleared.
+`$of` and `$err` are cleared.
 
 ### SRLI: Shift right logical immediate
 
@@ -643,9 +641,7 @@ Panic if:
 
 - `$rA` is a [reserved register](./index.md#semantics)
 
-`$of` is assigned the underflow of the operation, as though `$of` is the high byte of a 128-bit register.
-
-`$err` is cleared.
+`$of` and `$err` are cleared.
 
 ### SUB: Subtract
 


### PR DESCRIPTION
Bit shift to right was documented to set `$of` in case of underflow. This behavior is both unintuitive and different from the current implementation. See also https://github.com/FuelLabs/fuel-vm/pull/433 for a related bugfix.