### PR TITLE
Update Predicate Verificaiton

### DIFF
--- a/src/vm/index.md
+++ b/src/vm/index.md
@@ -134,7 +134,7 @@ For each such input in the transaction, the VM is [initialized](#vm-initializati
 
 Predicate verification will fail if gas is exhausted during execution.
 
-During predicate mode, hitting any [contract instruction](./instruction_set.md#contract-instructions) causes predicate verification to halt, returning Boolean `false`.
+During predicate mode, hitting any [contract instruction](./instruction_set.md#contract-instructions) except for `LDC`, `CROO`, `CSIZ` and `CPP` causes predicate verification to halt, returning Boolean `false`.
 
 In addition, during predicate mode if `$pc` is set to a value greater than the end of predicate bytecode (this would allow bytecode outside the actual predicate), predicate verification halts returning Boolean `false`.
 


### PR DESCRIPTION
### Abstract

We now allow for predicates to support certain contract instructions, so long as predicate verification remains monotonic.

### Opcodes

- `LDC`
- `CROO`
- `CPP`
- `CSIZ`