### PR TITLE
Hash the SMT leaf key to prevent tree structure manipulation

### DIFF
--- a/src/protocol/cryptographic_primitives.md
+++ b/src/protocol/cryptographic_primitives.md
@@ -49,6 +49,9 @@ A specification for the Sparse Merkle Tree is [here](https://github.com/celestia
 
 A specification describing a suite of test vectors and outputs of a Sparse Merkle Tree is [here](../tests/sparse_merkle_tree_tests.md).
 
+Before insertion of the key-value pair, each key of the Sparse Merkle Tree should be hashed with `sha256` to prevent tree structure manipulations.
+During the proof verification, the original leaf key should be hashed similarly. Otherwise, the root will not match.
+
 ## Public-Key Cryptography
 
 Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1-v2.pdf), with the curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). A highly-optimized library is available in C (<https://github.com/bitcoin-core/secp256k1>), with wrappers in Go (<https://pkg.go.dev/github.com/ethereum/go-ethereum/crypto/secp256k1>) and Rust (<https://docs.rs/crate/secp256k1>).


### PR DESCRIPTION
We use SMT in two places for contract balances and contract state. While it is not a huge problem for balances SMT root(because `AssetId` is randomly derived from `sha256`), it is a massive problem for contract state root. Each leaf key is specified by the user/developer for the storage key-value pair. The SMT is a vast data structure that uses some optimization that helps to improve its performance and occupied storage.

Based on the knowledge of how our SMT works inside, malicious users can manipulate the structure and make it work in a non-optimal way.
We've already faced that in the beta3 testnet.

[It is a snapshot](https://github.com/FuelLabs/fuel-core/blob/e4f5d65d471954b9cc1148ed067e9bb3f598bb7a/bin/e2e-test-client/src/tests/test_data/large_state/contract.json) of the state of the contract from the beta3 testnet. It has only 30k leafs but because those leafs are close to each other it produces 1.3m of nodes in the SMT. 

But if we [hash each leaf key](https://github.com/FuelLabs/fuel-core/pull/1207) it reduces the number of the nodes from 1.3m to only 70k. Because of the randomness leafs are distributed in a better way preventing a huge number of empty side nodes.

This PR proposes to hash each leaf key of any SMT to prevent any kind of manipulation.