### PR TITLE
New OutputData type

### DIFF
--- a/src/protocol/tx_format/output.md
+++ b/src/protocol/tx_format/output.md
@@ -7,6 +7,7 @@ enum OutputType : uint8 {
     Change = 2,
     Variable = 3,
     ContractCreated = 4,
+    Data = 5,
 }
 ```
 
@@ -88,3 +89,12 @@ This output type indicates that the output's amount and owner may vary based on 
 |--------------|------------|---------------------------------|
 | `contractID` | `byte[32]` | Contract ID.                    |
 | `stateRoot`  | `byte[32]` | Initial state root of contract. |
+
+## OutputData
+
+| name       | type       | description                          |
+|------------|------------|--------------------------------------|
+| `dataLength`   | `uint32` | The length of the data field. |
+| `data` | `byte[]` | The bytes data.                   |
+
+> **Note:** this output cannot be spent.


### PR DESCRIPTION
## Abstract

This output is for including arbitrary data within a transaction. This allows users and developers to include arbitrary data that can be signed over that cannot be included in a script, input, smart contract or within predicate code.

Note, this output is not spendable.

## Prior Art

https://en.bitcoin.it/wiki/OP_RETURN