### PR TITLE
Fix typo in instruction-set.md

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -792,7 +792,7 @@ Panic if:
 | Encoding    | `0x00 rA rB rC i`                                                                     |
 | Notes       |                                                                                       |
 
-The immediate value is interpreted identically to `WQOP`.
+The immediate value is interpreted identically to `WDOP`.
 
 Operations behave `$of` and `$err` similarly to their 64-bit counterparts.
 


### PR DESCRIPTION
The `WQOP` opcode interpretation of the immediate value currently refers to itself. This should instead refer to the `WDOP` opcode which has the definition for the interpretation.