### PR TITLE
docs: Add Merkle tree specs to cryptographic primitives

### DIFF
--- a/src/protocol/cryptographic-primitives.md
+++ b/src/protocol/cryptographic-primitives.md
@@ -3,7 +3,6 @@
 - [Hashing](#hashing)
 - [Merkle Trees](#merkle-trees)
   - [Binary Merkle Tree](#binary-merkle-tree)
-  - [Binary Merkle Sum Tree](#binary-merkle-sum-tree)
   - [Sparse Merkle Tree](#sparse-merkle-tree)
 - [EcDSA Public-Key Cryptography](#ecdsa-public-key-cryptography)
 - [EdDSA Public-Key Cryptography](#eddsa-public-key-cryptography)
@@ -14,44 +13,116 @@ All hashing is done with SHA-2-256 (also known as SHA-256), defined in [FIPS 180
 
 ## Merkle Trees
 
-Three Merkle tree structures are used: a Binary Merkle Tree (to commit to bytecode), a Binary Merkle Sum Tree (to commit to transactions and collected fees) and a Sparse Merkle Tree (to commit to contract storage, i.e. state).
+Two Merkle tree structures are used: a Binary Merkle Tree (to commit to bytecode) and a Sparse Merkle Tree (to commit to contract storage, i.e. state).
 
 ### Binary Merkle Tree
 
-A specification for the Binary Merkle Tree is [here](https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/data_structures.md#binary-merkle-tree).
+Binary Merkle trees are constructed in the same fashion as described in [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962), except for using [a different hashing function](#hashing). Leaves are hashed once to get leaf node values and internal node values are the hash of the concatenation of their children (either leaf nodes or other internal nodes).
 
-### Binary Merkle Sum Tree
+Nodes contain a single field:
 
-The Binary Merkle Sum Tree is an extension of the tree defined in [RFC-6962](https://www.rfc-editor.org/rfc/rfc9162).
+| name | type                      | description |
+|------|---------------------------|-------------|
+| `v`  | [HashDigest](#hashdigest) | Node value. |
 
-The root pair `(fee, digest)` of an empty tree is:
+The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
 
-```text
-(0x0000000000000000, hash()) = (0x0000000000000000, 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855)
+```C++
+node.v = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ```
 
-The root pair of a tree with one leaf:
+For leaf node `node` of leaf data `d`:
 
-```text
-(leaf.fee, hash(0x00 ++ leaf.fee ++ serialize(leaf)))
+```C++
+node.v = h(0x00, serialize(d))
 ```
 
-The root pair of a tree with two or more leaves is defined recursively:
+For internal node `node` with children `l` and `r`:
 
-```text
-(left.fee + right.fee, hash(0x01 ++ left.fee ++ left.digest ++ right.fee ++ right.digest))
+```C++
+node.v = h(0x01, l.v, r.v)
 ```
 
-In other words, the root pair is 40 bytes (8 for fee sum, 32 for hash digest).
+Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962#section-2.1.3).
+
+Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepended for leaf nodes while `0x01` is prepended for internal nodes. This avoids a second-preimage attack [where internal nodes are presented as leaves](https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack) trees with leaves at different heights.
+
+#### BinaryMerkleTreeInclusionProof
+
+| name       | type                          | description                                                     |
+|------------|-------------------------------|-----------------------------------------------------------------|
+| `siblings` | [HashDigest](#hashdigest)`[]` | Sibling hash values, ordered starting from the leaf's neighbor. |
+
+A proof for a leaf in a [binary Merkle tree](#binary-merkle-tree), as per Section 2.1.1 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962#section-2.1.1).
 
 ### Sparse Merkle Tree
 
-A specification for the Sparse Merkle Tree is [here](https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/data_structures.md#sparse-merkle-tree).
+Sparse Merkle Trees (SMTs) are _sparse_, i.e. they contain mostly empty leaves. They can be used as key-value stores for arbitrary data, as each leaf is keyed by its index in the tree. Storage efficiency is achieved through clever use of implicit defaults, avoiding the need to store empty leaves.
 
-A specification describing a suite of test vectors and outputs of a Sparse Merkle Tree is [here](../tests/sparse-merkle-tree-tests.md).
+Additional rules are added on top of plain [binary Merkle trees](#binary-merkle-tree):
+
+1. Default values are given to leaf nodes with empty leaves.
+1. While the above rule is sufficient to pre-compute the values of intermediate nodes that are roots of empty subtrees, a further simplification is to extend this default value to all nodes that are roots of empty subtrees. The 32-byte zero, i.e. `0x0000000000000000000000000000000000000000000000000000000000000000`, is used as the default value. This rule takes precedence over the above one.
+1. The number of hashing operations can be reduced to be logarithmic in the number of non-empty leaves on average, assuming a uniform distribution of non-empty leaf keys. An internal node that is the root of a subtree that contains exactly one non-empty leaf is replaced by that leaf's leaf node.
+
+Nodes contain a single field:
+
+| name | type                      | description |
+|------|---------------------------|-------------|
+| `v`  | [HashDigest](#hashdigest) | Node value. |
+
+In the base case, where a sparse Merkle tree has `height = 0`, the root of a tree is defined as the [hash](#hashing) of the empty string:
+
+```C++
+node.v = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+When a sparse Merkle tree has a height of 0, it can have no leaves, and, therefore, no default value children. The root is then calculated as the hash of the empty string, similar to that of an empty binary Merkle tree.
+
+For a tree with `height > 0`, the root of an empty tree is defined as the default value:
+
+```C++
+node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
+```
+
+Note that this is in contrast to the base case of the sparse and binary Merkle trees, where the root is the hash of the empty string. When a sparse Merkle tree has a height greater than 0, a new tree instance is composed of default value leaves. Nodes containing only default value children have the default value as well. Applying these rules recursively percolates the default value up to the tree's root.
+
+For leaf node `node` of leaf data `d` with key `k`:
+
+```C++
+node.v = h(0x00, k, h(serialize(d)))
+```
+
+The key of leaf nodes must be prepended, since the index of a leaf node that is not at maximum depth cannot be determined without this information. Leaf values are hashed so that they do not need to be included in full in non-membership proofs.
+
+For internal node `node` with children `l` and `r`:
+
+```C++
+node.v = h(0x01, l.v, r.v)
+```
+
+#### Insertion
 
 Before insertion of the key-value pair, each key of the Sparse Merkle Tree should be hashed with `sha256` to prevent tree structure manipulations.
 During the proof verification, the original leaf key should be hashed similarly. Otherwise, the root will not match.
+
+#### SparseMerkleTreeInclusionProof
+
+SMTs can further be extended with _compact_ proofs. [Merkle proofs](#verifying-annotated-merkle-proofs) are composed, among other things, of a list of sibling node values. We note that, since nodes that are roots of empty subtrees have known values (the default value), these values do not need to be provided explicitly; it is sufficient to simply identify which siblings in the Merkle branch are roots of empty subtrees, which can be done with one bit per sibling.
+
+For a Merkle branch of height `h`, an `h`-bit value is appended to the proof. The lowest bit corresponds to the sibling of the leaf node, and each higher bit corresponds to the next parent. A value of `1` indicates that the next value in the list of values provided explicitly in the proof should be used, and a value of `0` indicates that the default value should be used.
+
+A proof into an SMT is structured as:
+
+| name               | type                          | description                                                              |
+|--------------------|-------------------------------|--------------------------------------------------------------------------|
+| `depth`            | `uint16`                      | Depth of the leaf node. The root node is at depth `0`. Must be `<= 256`. |
+| `siblings`         | [HashDigest](#hashdigest)`[]` | Sibling hash values, ordered starting from the leaf's neighbor.          |
+| `includedSiblings` | `byte[32]`                    | Bitfield of explicitly included sibling hashes.                          |
+
+The `includedSiblings` is ordered by most-significant-byte first, with each byte ordered by most-significant-bit first. The lowest bit corresponds to the leaf node level.
+
+A specification describing a suite of test vectors and outputs of a Sparse Merkle Tree is [here](../tests/sparse-merkle-tree-tests.md).
 
 ## ECDSA Public-Key Cryptography
 

--- a/src/protocol/cryptographic-primitives.md
+++ b/src/protocol/cryptographic-primitives.md
@@ -11,6 +11,10 @@
 
 All hashing is done with SHA-2-256 (also known as SHA-256), defined in [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf).
 
+## HashDigest
+
+Output of the [hashing](#hashing) function. Exactly 256 bits (32 bytes) long.
+
 ## Merkle Trees
 
 Two Merkle tree structures are used: a Binary Merkle Tree (to commit to bytecode) and a Sparse Merkle Tree (to commit to contract storage, i.e. state).
@@ -108,7 +112,7 @@ During the proof verification, the original leaf key should be hashed similarly.
 
 #### SparseMerkleTreeInclusionProof
 
-SMTs can further be extended with _compact_ proofs. [Merkle proofs](#verifying-annotated-merkle-proofs) are composed, among other things, of a list of sibling node values. We note that, since nodes that are roots of empty subtrees have known values (the default value), these values do not need to be provided explicitly; it is sufficient to simply identify which siblings in the Merkle branch are roots of empty subtrees, which can be done with one bit per sibling.
+SMTs can further be extended with _compact_ proofs. Merkle proofs are composed, among other things, of a list of sibling node values. We note that, since nodes that are roots of empty subtrees have known values (the default value), these values do not need to be provided explicitly; it is sufficient to simply identify which siblings in the Merkle branch are roots of empty subtrees, which can be done with one bit per sibling.
 
 For a Merkle branch of height `h`, an `h`-bit value is appended to the proof. The lowest bit corresponds to the sibling of the leaf node, and each higher bit corresponds to the next parent. A value of `1` indicates that the next value in the list of values provided explicitly in the proof should be used, and a value of `0` indicates that the default value should be used.
 

--- a/src/protocol/cryptographic-primitives.md
+++ b/src/protocol/cryptographic-primitives.md
@@ -61,7 +61,7 @@ Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepend
 
 A proof for a leaf in a [binary Merkle tree](#binary-merkle-tree), as per Section 2.1.1 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962#section-2.1.1).
 
-In some contexts, the array of sibling hashes is also known as the proof set. Note that proof format prescribes that leaf data be in its original, unhashed state, while the proof set (array of sibling data) uses hashed data. This format precludes the proof set from including the leaf data undergoing the proof itself; rather, proof verification explicitly requires hashing the leaf data during the calculation of the proof set root. 
+In some contexts, the array of sibling hashes is also known as the proof set. Note that proof format prescribes that leaf data be in its original, unhashed state, while the proof set (array of sibling data) uses hashed data. This format precludes the proof set from itself including the leaf data from the leaf undergoing the proof; rather, proof verification explicitly requires hashing the leaf data during the calculation of the proof set root.
 
 ### Sparse Merkle Tree
 

--- a/src/protocol/cryptographic-primitives.md
+++ b/src/protocol/cryptographic-primitives.md
@@ -51,13 +51,17 @@ Note that rather than duplicating the last node if there are an odd number of no
 
 Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepended for leaf nodes while `0x01` is prepended for internal nodes. This avoids a second-preimage attack [where internal nodes are presented as leaves](https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack) trees with leaves at different heights.
 
-#### BinaryMerkleTreeInclusionProof
+#### Binary Merkle Tree Inclusion Proofs
 
 | name       | type                          | description                                                     |
 |------------|-------------------------------|-----------------------------------------------------------------|
+| `root`     | [HashDigest](#hashdigest)`[]` | The expected root of the Merkle tree.                           |
+| `data`     | Bytes                         | The data of the leaf (unhashed).                                |
 | `siblings` | [HashDigest](#hashdigest)`[]` | Sibling hash values, ordered starting from the leaf's neighbor. |
 
 A proof for a leaf in a [binary Merkle tree](#binary-merkle-tree), as per Section 2.1.1 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962#section-2.1.1).
+
+In some contexts, the array of sibling hashes is also known as the proof set. Note that proof format prescribes that leaf data be in its original, unhashed state, while the proof set (array of sibling data) uses hashed data. This format precludes the proof set from including the leaf data undergoing the proof itself; rather, proof verification explicitly requires hashing the leaf data during the calculation of the proof set root. 
 
 ### Sparse Merkle Tree
 
@@ -110,7 +114,7 @@ node.v = h(0x01, l.v, r.v)
 Before insertion of the key-value pair, each key of the Sparse Merkle Tree should be hashed with `sha256` to prevent tree structure manipulations.
 During the proof verification, the original leaf key should be hashed similarly. Otherwise, the root will not match.
 
-#### SparseMerkleTreeInclusionProof
+#### Sparse Merkle Tree Inclusion Proofs
 
 SMTs can further be extended with _compact_ proofs. Merkle proofs are composed, among other things, of a list of sibling node values. We note that, since nodes that are roots of empty subtrees have known values (the default value), these values do not need to be provided explicitly; it is sufficient to simply identify which siblings in the Merkle branch are roots of empty subtrees, which can be done with one bit per sibling.
 


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-vm/issues/501#issue-1792237720

This PR gives the Fuel specs its own Merkle tree specification, and removes links to the archived Celestia spec. This gives Fuel ownership over its own Merkle tree specification and allows us to adapt it to our design. 

Specifically, this PR copies the specification for the binary and sparse Merkle trees as described in the Celestia spec. Additional comments are my own, and describe in more detail topics like the BMT proof format. 

Lastly, this PR removes the specification for the binary Merkle sum tree (BMST). The BMST is currently not supported by Fuel and does not fall under the Fuel specification at this time.   