### PR TITLE
`ecr` opcode is no longer supported

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2269,7 +2269,7 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 |-------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
 | Operation   | ```MEM[$rA, 64] = ecrecover_r1(MEM[$rB, 64], MEM[$rC, 32]);```                                                              |
-| Syntax      | `eck1 $rA, $rB, $rC`                                                                                                        |
+| Syntax      | `ecr1 $rA, $rB, $rC`                                                                                                        |
 | Encoding    | `0x00 rA rB rC -`                                                                                                           |
 | Notes       |                                                                                                                             |
 
@@ -2295,7 +2295,7 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | Description | Verification recovered from 32-byte public key starting at `$rA` and 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
 | Operation   | ```ed19verify(MEM[$rA, 32], MEM[$rB, 64], MEM[$rC, 32]);```                                                                                         |
-| Syntax      | `eck1 $rA, $rB, $rC`                                                                                                                                |
+| Syntax      | `ed19 $rA, $rB, $rC`                                                                                                                                |
 | Encoding    | `0x00 rA rB rC -`                                                                                                                                   |
 | Notes       |                                                                                                                                                     |
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2243,7 +2243,7 @@ All these instructions advance the program counter `$pc` by `4` after performing
 |-------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
 | Operation   | ```MEM[$rA, 64] = ecrecover_k1(MEM[$rB, 64], MEM[$rC, 32]);```                                                              |
-| Syntax      | `ecr $rA, $rB, $rC`                                                                                                         |
+| Syntax      | `eck1 $rA, $rB, $rC`                                                                                                        |
 | Encoding    | `0x00 rA rB rC -`                                                                                                           |
 | Notes       |                                                                                                                             |
 
@@ -2269,7 +2269,7 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 |-------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
 | Operation   | ```MEM[$rA, 64] = ecrecover_r1(MEM[$rB, 64], MEM[$rC, 32]);```                                                              |
-| Syntax      | `ecr $rA, $rB, $rC`                                                                                                         |
+| Syntax      | `eck1 $rA, $rB, $rC`                                                                                                        |
 | Encoding    | `0x00 rA rB rC -`                                                                                                           |
 | Notes       |                                                                                                                             |
 
@@ -2295,7 +2295,7 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | Description | Verification recovered from 32-byte public key starting at `$rA` and 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
 | Operation   | ```ed19verify(MEM[$rA, 32], MEM[$rB, 64], MEM[$rC, 32]);```                                                                                         |
-| Syntax      | `ecr $rA, $rB, $rC`                                                                                                                                 |
+| Syntax      | `eck1 $rA, $rB, $rC`                                                                                                                                |
 | Encoding    | `0x00 rA rB rC -`                                                                                                                                   |
 | Notes       |                                                                                                                                                     |
 


### PR DESCRIPTION
Closes #512 

I assume that the 3 instructions are meant to be `eck1`, `ecr1` and `ed19` based on the names of the functions that are called but I do not know.

Since the previous `ecr` opcode was used in all 3 instructions I have put the `eck1` opcode in all 3 as well. If that is incorrect then lmk and I'll update.