### PR TITLE
Remove CHAIN_ID from predicate ID calculation

### DIFF
--- a/src/identifiers/predicate-id.md
+++ b/src/identifiers/predicate-id.md
@@ -1,6 +1,6 @@
 # Predicate ID
 
 For an input of type `InputType.Coin` or `InputType.Message`, `input`, the predicate owner is calculated as:
-`sha256(0x4655454C ++ CHAIN_ID ++ root(input.predicate))`, where `root` is the Merkle root of
+`sha256(0x4655454C ++ root(input.predicate))`, where `root` is the Merkle root of
 [the binary Merkle tree](../protocol/cryptographic-primitives.md#binary-merkle-tree) each leaf being 16KiB of instructions.
 If the bytecode is not a multiple of 16 KiB, the final leaf should be zero-padded rounding up to the nearest multiple of 8 bytes.


### PR DESCRIPTION
ChainId was previously added to the predicate ID calculation (see #462) to avoid replay attacks with predicates. However, replay attacks are already not a significant issue due to Fuel's architecture, and the inclusion of the ChainId causes other issues.

## Replay attacks

Generally, predicate-based account-abstraction implementations use the transaction ID as the input to the signature to verify. This already provides the same level of replay protection as a normal Fuel transaction, as that TxId includes all the inputs which we can assume to be unique.

Other implementations of predicates involve verifying an arbitrary signature provided, however these signatures are vulnerable to replay attacks regardless of the predicate's address. These attacks are alleviated by including the chain ID in the signed message itself, and having the predicate load the chain ID using the `GM` opcode.

## The need for cross-chain shared addresses

If predicates are to provide native account abstraction on Fuel, then it's important that predicate addresses are the same across various chains. For example, if a user connects their Metamask to Fuel using a predicate, they should expect to have the same derived Fuel address on all Fuel chains.

Having different addresses on different chains can lead to user loss-of-funds. One example of this is the case of Wintermute, an experienced DeFi market maker, [transferring $15m worth of OP tokens to an address on Optimism that they expected to be a Gnosis safe](https://www.coindesk.com/tech/2022/06/09/15m-of-optimism-tokens-stolen-by-an-attacker-after-wintermute-sent-wrong-wallet-address/), when in reality that address was only the expected multisig on L1.