### PR TITLE
Update Secp256r1 Instruction with Message Length as Immediate

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2268,8 +2268,8 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 
 |             |                                                                                                                             |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------|
-| Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC` to `$rC + $rD`. |
-| Operation   | ```MEM[$rA, 64] = ecrecover_r1(MEM[$rB, 64], MEM[$rC, $rC + $rD]);```                                                              |
+| Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message starting at `$rC` with a length of `$rD`. |
+| Operation   | ```MEM[$rA, 64] = ecrecover_r1(MEM[$rB, 64], MEM[$rC, $rD]);```                                                              |
 | Syntax      | `ecr1 $rA, $rB, $rC, $rD`                                                                                                        |
 | Encoding    | `0x00 rA rB rC rD`                                                                                                           |
 | Notes       |                                                                                                                             |

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2268,10 +2268,10 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 
 |             |                                                                                                                             |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------|
-| Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
-| Operation   | ```MEM[$rA, 64] = ecrecover_r1(MEM[$rB, 64], MEM[$rC, 32]);```                                                              |
-| Syntax      | `ecr1 $rA, $rB, $rC`                                                                                                        |
-| Encoding    | `0x00 rA rB rC -`                                                                                                           |
+| Description | The 64-byte public key (x, y) recovered from 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC` to `$rC + $rD`. |
+| Operation   | ```MEM[$rA, 64] = ecrecover_r1(MEM[$rB, 64], MEM[$rC, $rC + $rD]);```                                                              |
+| Syntax      | `ecr1 $rA, $rB, $rC, $rD`                                                                                                        |
+| Encoding    | `0x00 rA rB rC rD`                                                                                                           |
 | Notes       |                                                                                                                             |
 
 Panic if:
@@ -2287,8 +2287,6 @@ Panic if:
 Signatures and signature verification are specified [here](../protocol/cryptographic-primitives.md#ecdsa-public-key-cryptography).
 
 If the signature cannot be verified, `MEM[$rA, 64]` is set to `0` and `$err` is set to `1`, otherwise `$err` is cleared.
-
-To get the address from the public key, hash the public key with [SHA-2-256](../protocol/cryptographic-primitives.md#hashing).
 
 ### ED19: edDSA curve25519 verification
 


### PR DESCRIPTION
## Abstract
The current specified implementation of the Secp256r1 opcode assumes a 32 byte message being signed over, however, in the current widespread use of the curve in WebAuthn and passkeys, the signed message is larger than 32 bytes (e.g. 69 bytes).

## Solution
Allow the immediate value to specify a more flexible message length beyond or below 32 bytes.

## Considerations
- For consistency, we should perhaps also enable a more flexible message length for the secp256k1 opcode.