### PR TITLE
Limit the number of receipts to u16::MAX

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -125,6 +125,8 @@ This page provides a description of all instructions for the FuelVM. Encoding is
 - The syntax `MEM[x, y]` used in this page means the memory range starting at byte `x`, of length `y` bytes.
 - The syntax `STATE[x, y]` used in this page means the sequence of storage slots starting at key `x` and spanning `y` bytes.
 
+### Panics
+
 Some instructions may _panic_, i.e. enter an unrecoverable state. Additionally, attempting to execute an instruction not in this list causes a panic and consumes no gas. How a panic is handled depends on [context](./index.md#contexts):
 
 - In a predicate context, cease VM execution and return `false`.
@@ -146,6 +148,12 @@ then append an additional receipt to the list of receipts, again modifying `tx.r
 | `type`     | `ReceiptType` | `ReceiptType.ScriptResult`  |
 | `result`   | `uint64`      | `1`                         |
 | `gas_used` | `uint64`      | Gas consumed by the script. |
+
+### Receipts
+
+The number of receipts is limited to 2<sup>16</sup>, with the last two reserved to panic and script result receipts. Trying to add any other receipts after 2<sup>16</sup>-2 will panic.
+
+### Effects
 
 A few instructions are annotated with the _effects_ they produce, the table below explains each effect:
 

--- a/src/identifiers/utxo-id.md
+++ b/src/identifiers/utxo-id.md
@@ -18,7 +18,7 @@ The ID of a message is computed as the [hash](../protocol/cryptographic-primitiv
 
 ### Message Nonce
 
-The nonce value for `InputMessage` is determined by the sending system and is published at the time the message is sent. The nonce value for `OutputMessage` is computed as the [hash](../protocol/cryptographic-primitives.md#hashing) of the [Transaction ID](./transaction-id.md) that emitted the message and the index of the message receipt `uint8`: `hash(byte[32] ++ uint8)`.
+The nonce value for `InputMessage` is determined by the sending system and is published at the time the message is sent. The nonce value for `OutputMessage` is computed as the [hash](../protocol/cryptographic-primitives.md#hashing) of the [Transaction ID](./transaction-id.md) that emitted the message and the index of the message receipt `uint16`: `hash(byte[32] ++ uint16)`.
 
 ## Fee ID
 

--- a/src/identifiers/utxo-id.md
+++ b/src/identifiers/utxo-id.md
@@ -18,7 +18,7 @@ The ID of a message is computed as the [hash](../protocol/cryptographic-primitiv
 
 ### Message Nonce
 
-The nonce value for `InputMessage` is determined by the sending system and is published at the time the message is sent. The nonce value for `OutputMessage` is computed as the [hash](../protocol/cryptographic-primitives.md#hashing) of the [Transaction ID](./transaction-id.md) that emitted the message and the index of the message receipt `uint16`: `hash(byte[32] ++ uint16)`.
+The nonce value for `InputMessage` is determined by the sending system and is published at the time the message is sent. The nonce value for `OutputMessage` is computed as the [hash](../protocol/cryptographic-primitives.md#hashing) of the [Transaction ID](./transaction-id.md) that emitted the message and the index of the message receipt `uint16` (with canonical encoding): `hash(byte[32] ++ canonical(uint16))`.
 
 ## Fee ID
 


### PR DESCRIPTION
Increases the receipt limit from `u8::MAX` to `u16::MAX`, leaving space for panic and script result. The old limit was not enforced, but https://github.com/FuelLabs/fuel-vm/pull/633 is going to enforce the new rules defined here.

The number of receipts is limited separtely from gas, since adding more receipts slows down all instructions that operate on them. Moreover, this change makes the upper bound for memory use clear.