### PR TITLE
Update Specs to Include Gas Price changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 book
+.idea/

--- a/spell-check-custom-words.txt
+++ b/spell-check-custom-words.txt
@@ -269,3 +269,4 @@ OOB
 unspendable
 priori
 padding
+incentivize

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2529,7 +2529,7 @@ Get [fields from the transaction](../tx-format/transaction.md).
 | `GTF_WITNESS_DATA_LENGTH`                 | `0x400` | `tx.witnesses[$rB].dataLength`                                    |
 | `GTF_WITNESS_DATA`                        | `0x401` | Memory address of `tx.witnesses[$rB].data`                        |
 | `GTF_POLICY_TYPES`                        | `0x500` | `tx.policies.policyTypes`                                         |
-| `GTF_POLICY_GAS_PRICE`                    | `0x501` | `tx.policies[0x00].gasPrice`                                      |
+| `GTF_POLICY_TIP`                          | `0x501` | `tx.policies[0x00].tip`                                           |
 | `GTF_POLICY_WITNESS_LIMIT`                | `0x502` | `tx.policies[count_ones(0b11 & tx.policyTypes) - 1].witnessLimit` |
 | `GTF_POLICY_MATURITY`                     | `0x503` | `tx.policies[count_ones(0b111 & tx.policyTypes) - 1].maturity`    |
 | `GTF_POLICY_MAX_FEE`                      | `0x504` | `tx.policies[count_ones(0b1111 & tx.policyTypes) - 1].maxFee`     |

--- a/src/protocol/tx-validity.md
+++ b/src/protocol/tx-validity.md
@@ -238,7 +238,7 @@ def available_balance(tx, assetId) -> int:
 def unavailable_balance(tx, assetId) -> int:
     sentBalance = sum_outputs(tx, assetId)
     # Total fee balance
-    feeBalance = reserved_fee_balance(tx, assetId)
+    feeBalance = tx.policies.max_fee
     # Only base asset can be used to pay for gas
     if assetId == 0:
         return sentBalance + feeBalance

--- a/src/protocol/tx-validity.md
+++ b/src/protocol/tx-validity.md
@@ -212,6 +212,19 @@ def max_gas(tx) -> int:
     if tx.type == TransactionType.Script:
        gas = gas + tx.gasLimit
     return gas
+    
+    
+def maxFee(tx, assetId, gasPrice) -> int:
+    """
+    Computes the maximum potential amount of fees that may need to be charged to process a transaction.
+    """
+    maxGas = max_gas(tx)
+    feeBalance = gas_to_fee(maxGas, gasPrice)
+    # Only base asset can be used to pay for gas
+    if assetId == 0:
+        return feeBalance
+    else:
+        return 0
 
 
 def available_balance(tx, assetId) -> int:

--- a/src/tx-format/index.md
+++ b/src/tx-format/index.md
@@ -18,4 +18,5 @@ The Fuel Transaction Format.
   - [`OutputVariable`](./output.md#outputvariable)
   - [`OutputContractCreated`](./output.md#outputcontractcreated)
 - [`Witness`](./witness.md)
+- [`Policy`](./policy.md)
 - [`TXPointer`](./tx-pointer.md)

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -3,7 +3,7 @@
 ```c++
 // index using powers of 2 for efficient bitmasking
 enum PolicyType : uint32 {
-    GasPrice = 1,
+    Tip = 1,
     WitnessLimit = 2,
     Maturity = 4,
     MaxFee = 8,
@@ -14,11 +14,11 @@ enum PolicyType : uint32 {
 |--------|---------------------------------------------------------------------------------------|--------------|
 | `data` | One of [`GasPrice`](#gasprice), [`WitnessLimit`](#witnesslimit), or [`Maturity`](#maturity) | Policy data. |
 
-## `GasPrice`
+## `Tip`
 
-| name       | type     | description               |
-|------------|----------|---------------------------|
-| `gasPrice` | `uint64` | Gas price for transaction |
+| name       | type     | description                                                                                   |
+|------------|----------|-----------------------------------------------------------------------------------------------|
+| `gasPrice` | `uint64` | Additional, optional fee in `BASE_ASSET` to incentivize block producer to include transaction |
 
 ## `WitnessLimit`
 

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -18,7 +18,7 @@ enum PolicyType : uint32 {
 
 | name       | type     | description                                                                                   |
 |------------|----------|-----------------------------------------------------------------------------------------------|
-| `gasPrice` | `uint64` | Additional, optional fee in `BASE_ASSET` to incentivize block producer to include transaction |
+| `tip` | `uint64` | Additional, optional fee in `BASE_ASSET` to incentivize block producer to include transaction |
 
 ## `WitnessLimit`
 

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -44,9 +44,9 @@ Transaction is invalid if:
 
 ## `MaxFee`
 
-| name      | type     | description                                                                                                                                |
-|-----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `max_fee` | `uint64` | The maximum fee payable by this transaction using `BASE_ASSET`. This is used to check transactions before the actual `gas_price` is known. |
+| name      | type     | description                                                                                                                                                           |
+|-----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `max_fee` | `uint64` | Required policy to specify the maximum fee payable by this transaction using `BASE_ASSET`. This is used to check transactions before the actual `gas_price` is known. |
 
 Transaction is invalid if:
 

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -52,4 +52,4 @@ Transaction is invalid if:
 
 - `max_fee` is not set
 - `max_fee > sum_inputs(tx, BASE_ASSET_ID) - sum_outputs(tx, BASE_ASSET_ID)`
-- `max_fee < reserved_fee_balance(tx, BASE_ASSET_ID)`
+- `max_fee < max_fee(tx, BASE_ASSET_ID)`

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -51,4 +51,4 @@ Transaction is invalid if:
 Transaction is invalid if:
 
 - `max_fee > sum_inputs(tx, BASE_ASSET_ID) - sum_outputs(tx, BASE_ASSET_ID)`
-- `max_fee < max_fee(tx, BASE_ASSET_ID)`
+- `max_fee < max_fee(tx, BASE_ASSET_ID, gas_price)`

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -44,11 +44,12 @@ Transaction is invalid if:
 
 ## `MaxFee`
 
-| name      | type     | description                                                     |
-|-----------|----------|-----------------------------------------------------------------|
-| `max_fee` | `uint64` | The maximum fee payable by this transaction using `BASE_ASSET`. |
+| name      | type     | description                                                                                                                                |
+|-----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `max_fee` | `uint64` | The maximum fee payable by this transaction using `BASE_ASSET`. This is used to check transactions before the actual `gas_price` is known. |
 
 Transaction is invalid if:
 
+- `max_fee` is not set
 - `max_fee > sum_inputs(tx, BASE_ASSET_ID) - sum_outputs(tx, BASE_ASSET_ID)`
 - `max_fee < reserved_fee_balance(tx, BASE_ASSET_ID)`

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -50,6 +50,5 @@ Transaction is invalid if:
 
 Transaction is invalid if:
 
-- `max_fee` is not set
 - `max_fee > sum_inputs(tx, BASE_ASSET_ID) - sum_outputs(tx, BASE_ASSET_ID)`
 - `max_fee < max_fee(tx, BASE_ASSET_ID)`

--- a/src/tx-format/policy.md
+++ b/src/tx-format/policy.md
@@ -10,9 +10,9 @@ enum PolicyType : uint32 {
 }
 ```
 
-| name   | type                                                                                  | description  |
-|--------|---------------------------------------------------------------------------------------|--------------|
-| `data` | One of [`GasPrice`](#gasprice), [`WitnessLimit`](#witnesslimit), or [`Maturity`](#maturity) | Policy data. |
+| name   | type                                                                              | description  |
+|--------|-----------------------------------------------------------------------------------|--------------|
+| `data` | One of [`Tip`](#tip), [`WitnessLimit`](#witnesslimit), or [`Maturity`](#maturity) | Policy data. |
 
 ## `Tip`
 

--- a/src/tx-format/transaction.md
+++ b/src/tx-format/transaction.md
@@ -87,6 +87,7 @@ Transaction is invalid if:
 - `scriptLength * 4 != len(script)`
 - `scriptDataLength != len(scriptData)`
 - `max_gas(tx) > MAX_GAS_PER_TX`
+- No policy of type `PolicyType.MaxFee` is set
 - `count_ones(policyTypes) > count_variants(PolicyType)`
 - `policyTypes > sum_variants(PolicyType)`
 - `len(policies) > count_ones(policyTypes)`

--- a/src/tx-format/transaction.md
+++ b/src/tx-format/transaction.md
@@ -136,6 +136,7 @@ Transaction is invalid if:
 - `storageSlotsCount > MAX_STORAGE_SLOTS`
 - `max_gas(tx) > MAX_GAS_PER_TX`
 - The [Sparse Merkle tree](../protocol/cryptographic-primitives.md#sparse-merkle-tree) root of `storageSlots` is not equal to the `stateRoot` of the one `OutputType.ContractCreated` output
+- No policy of type `PolicyType.MaxFee` is set
 - `count_ones(policyTypes) > count_variants(PolicyType)`
 - `policyTypes > sum_variants(PolicyType)`
 - `len(policies) > count_ones(policyTypes)`

--- a/src/tx-format/transaction.md
+++ b/src/tx-format/transaction.md
@@ -87,7 +87,6 @@ Transaction is invalid if:
 - `scriptLength * 4 != len(script)`
 - `scriptDataLength != len(scriptData)`
 - `max_gas(tx) > MAX_GAS_PER_TX`
-- No policy of type `PolicyType.GasPrice`
 - `count_ones(policyTypes) > count_variants(PolicyType)`
 - `policyTypes > sum_variants(PolicyType)`
 - `len(policies) > count_ones(policyTypes)`
@@ -138,7 +137,6 @@ Transaction is invalid if:
 - `storageSlotsCount > MAX_STORAGE_SLOTS`
 - `max_gas(tx) > MAX_GAS_PER_TX`
 - The [Sparse Merkle tree](../protocol/cryptographic-primitives.md#sparse-merkle-tree) root of `storageSlots` is not equal to the `stateRoot` of the one `OutputType.ContractCreated` output
-- No policy of type `PolicyType.GasPrice`
 - `count_ones(policyTypes) > count_variants(PolicyType)`
 - `policyTypes > sum_variants(PolicyType)`
 - `len(policies) > count_ones(policyTypes)`

--- a/src/tx-format/transaction.md
+++ b/src/tx-format/transaction.md
@@ -148,13 +148,14 @@ Creates a contract with contract ID as computed [here](../identifiers/contract-i
 The transaction is created by the block producer and is not signed. Since it is not usable outside of block creation or execution, all fields must be fully set upon creation without any zeroing.
 This means that the transaction ID must also include the correct `txPointer` value, not zeroed out.
 
-| name             | type                          | description                                          |
-|------------------|-------------------------------|------------------------------------------------------|
-| `txPointer`      | [`TXPointer`](./tx-pointer.md)  | The location of the `Mint` transaction in the block. |
-| `inputContract`  | [`InputContract`](./input.md)   | The contract UTXO that assets are minted to.         |
-| `outputContract` | [`OutputContract`](./output.md) | The contract UTXO that assets are being minted to.   |
-| `mintAmount`     | `uint64`                      | The amount of funds minted.                          |
-| `mintAssetId`    | `byte[32]`                    | The asset IDs corresponding to the minted amount.    |
+| name             | type                            | description                                                                |
+|------------------|---------------------------------|----------------------------------------------------------------------------|
+| `txPointer`      | [`TXPointer`](./tx-pointer.md)  | The location of the `Mint` transaction in the block.                       |
+| `inputContract`  | [`InputContract`](./input.md)   | The contract UTXO that assets are minted to.                               |
+| `outputContract` | [`OutputContract`](./output.md) | The contract UTXO that assets are being minted to.                         |
+| `mintAmount`     | `uint64`                        | The amount of funds minted.                                                |
+| `mintAssetId`    | `byte[32]`                      | The asset IDs corresponding to the minted amount.                          |
+| `gasPrice`       | `uint64`                        | The gas price to be used in calculating all fees for transactions on block |
 
 Transaction is invalid if:
 


### PR DESCRIPTION
https://github.com/FuelLabs/fuel-specs/pull/546

This includes the changes for:
- Remove`gas_price` from tx
- Include `gas_price` on `Mint` tx
- Remove `GasPrice` policy
- Add `Tip` policy
- Make `MaxFee` mandatory

Since there is no concept of the client API in these specs, and also the implementation of tx checks, I didn't include:
- Anything wrt to `gas_price` estimate or latest `gas_price` API endpoints
- Anything wrt the metadata changes for `Checked<Tx>`

That's fine if we don't want the scope of the VM to include those sort of things, but it's not clear to me _what_ these specs are constrained by.