### PR TITLE
Removed `bytecodeLength` field since this information is available from the witness

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2476,7 +2476,6 @@ Get [fields from the transaction](../tx-format/transaction.md).
 | `GTF_SCRIPT_OUTPUT_AT_INDEX`              | `0x00C` | Memory address of `t.outputs[$rB]`                                |
 | `GTF_SCRIPT_WITNESS_AT_INDEX`             | `0x00D` | Memory address of `tx.witnesses[$rB]`                             |
 | `GTF_TX_LENGTH`                           | `0x00E` | Length of raw transaction types in memory                        |
-| `GTF_CREATE_BYTECODE_LENGTH`              | `0x100` | `tx.bytecodeLength`                                               |
 | `GTF_CREATE_BYTECODE_WITNESS_INDEX`       | `0x101` | `tx.bytecodeWitnessIndex`                                         |
 | `GTF_CREATE_STORAGE_SLOTS_COUNT`          | `0x102` | `tx.storageSlotsCount`                                            |
 | `GTF_CREATE_INPUTS_COUNT`                 | `0x103` | `tx.inputsCount`                                                  |

--- a/src/tx-format/transaction.md
+++ b/src/tx-format/transaction.md
@@ -102,7 +102,6 @@ The receipts root `receiptsRoot` is the root of the [binary Merkle tree](../prot
 
 | name                   | type                        | description                                       |
 |------------------------|-----------------------------|---------------------------------------------------|
-| `bytecodeLength`       | `uint64`                    | Contract bytecode length, in instructions.        |
 | `bytecodeWitnessIndex` | `uint16`                    | Witness index of contract bytecode to create.     |
 | `salt`                 | `byte[32]`                  | Salt.                                             |
 | `storageSlotsCount`    | `uint64`                    | Number of storage slots to initialize.            |
@@ -128,8 +127,7 @@ Transaction is invalid if:
 - More than one output is of type `OutputType.Change` with `asset_id` of zero
 - Any output is of type `OutputType.Change` with non-zero `asset_id`
 - It does not have exactly one output of type `OutputType.ContractCreated`
-- `bytecodeLength * 4 > CONTRACT_MAX_SIZE`
-- `tx.data.witnesses[bytecodeWitnessIndex].dataLength != bytecodeLength * 4`
+- `tx.data.witnesses[bytecodeWitnessIndex].dataLength > CONTRACT_MAX_SIZE`
 - `bytecodeWitnessIndex >= tx.witnessesCount`
 - The keys of `storageSlots` are not in ascending lexicographic order
 - The computed contract ID (see below) is not equal to the `contractID` of the one `OutputType.ContractCreated` output


### PR DESCRIPTION
Corresponding change on VM side https://github.com/FuelLabs/fuel-vm/pull/709.

Removed the `bytecodeLength` field since this information is available from the witness. The transaction still will be unique and unchanged because of the `contract_id` from `Output::ContractCreated`.