### PR TITLE
Fix false claim that message count is included on header

### DIFF
--- a/src/protocol/relayer.md
+++ b/src/protocol/relayer.md
@@ -15,7 +15,7 @@ The message outbox is the set of messages sent to the L1 blockchain from the Fue
 
 The event inbox is the set of events received from the L1 blockchain by the Fuel blockchain.
 
-The block producer will receive the list of events from the L1 by some relayer, and then include both the count and the
+The block producer will receive the list of events from the L1 by some relayer, and then include the
 merkle root of the events in the block header.
 
 There are two types of events that can be received from the L1:

--- a/src/protocol/relayer.md
+++ b/src/protocol/relayer.md
@@ -15,7 +15,7 @@ The message outbox is the set of messages sent to the L1 blockchain from the Fue
 
 The event inbox is the set of events received from the L1 blockchain by the Fuel blockchain.
 
-The block producer will receive the list of events from the L1 by some relayer, and then include the
+The block producer will receive a list of events from the L1 by some relayer, and then include the
 merkle root of the events in the block header.
 
 There are two types of events that can be received from the L1:


### PR DESCRIPTION
Something was missed in this [PR](https://github.com/FuelLabs/fuel-specs/pull/571) and this fixes it.

### Before requesting review
- [x] I have reviewed the code myself

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
