### PR TITLE
Clarify that non-zero reserved part of an instruction causes vm panic

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -127,7 +127,7 @@ This page provides a description of all instructions for the FuelVM. Encoding is
 
 ### Panics
 
-Some instructions may _panic_, i.e. enter an unrecoverable state. Additionally, attempting to execute an instruction not in this list causes a panic and consumes no gas. How a panic is handled depends on [context](./index.md#contexts):
+Some instructions may _panic_, i.e. enter an unrecoverable state. Additionally, attempting to execute an instruction not in this list causes a panic and consumes no gas. Instructions with unspecified (reserved) part having a non-zero value will likewise panic.  How a panic is handled depends on [context](./index.md#contexts):
 
 - In a predicate context, cease VM execution and return `false`.
 - In other contexts, revert (described below).


### PR DESCRIPTION
VM PR: https://github.com/FuelLabs/fuel-vm/pull/737

What is says on the tin. This is a small but breaking change. It's unlikely to cause any breakage, as no Sway code or code constructed using the fuel-asm helper functions is affected.

This change is originating from an audit report that pointed out the likely unintentional behavior of the unused part of instruction is ignored.

### Before requesting review
- [x] I have reviewed the code myself
