### PR TITLE
Zero $flag on call

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -1732,6 +1732,7 @@ A [call frame](./index.md#call-frames) is pushed at `$sp`. In addition to fillin
 1. `$fp = $sp` (on top of the previous call frame is the beginning of this call frame)
 1. Set `$ssp` and `$sp` to the start of the writable stack area of the call frame.
 1. Set `$pc` and `$is` to the starting address of the code.
+1. `$flag` set to zero.
 1. `$bal = $rB` (forward coins)
 1. `$cgas = $rD` or all available gas (forward gas)
 


### PR DESCRIPTION
VM PR: https://github.com/FuelLabs/fuel-vm/pull/743

Called contracts shouldn't inherit the `$flag` register.

### Before requesting review
- [x] I have reviewed the code myself
