### PR TITLE
Updates ABI spec with hash based ids, versions and program type.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -28,6 +28,7 @@
   - [Receipts](./abi/receipts.md)
   - [Function Selector Encoding](./abi/fn-selector-encoding.md)
   - [Argument Encoding](./abi/argument-encoding.md)
+  - [Hash Based Ids](./abi/hash-based-ids.md)
 - [FuelVM](./fuel-vm/index.md)
   - [Instruction Set](./fuel-vm/instruction-set.md)
 - [Networks](./networks/index.md)

--- a/src/abi/hash-based-ids.md
+++ b/src/abi/hash-based-ids.md
@@ -1,0 +1,72 @@
+# Hash based IDs
+
+Hash based ids are deterministically generated from associated types and are used in the JSON ABI for `type` IDs and for `logId`.
+This document specifies how the hash based IDS are generated for `type` IDs and for `logId`.
+
+## Generation
+
+Hash based ids for `type` IDs are generated from the `sha256` of a string that represents the type.
+
+For `logIds` we use the first 8 bytes of the `sha256` of a string that represents the type, this is because the `LOG` and `LOGD` opcodes use a 64bit value as log id.
+
+## String representation of types
+
+For describing the string representation of type we will use the notation `{abi_str(T)}` that should be replaced by the respective ABI string representation of the respective type `T`.
+
+### Intrinsics
+
+ `u8`   => `"u8"`
+ `u16`  => `"u16"`
+ `u32`  => `"u32"`
+ `u64`  => `"u64"`
+ `u256` => `"u256"`
+ `b256` => `"b256"`
+ `bool` => `"bool"`
+
+### String arrays
+
+  String array of size `1` => `"str[1]"`
+  String array of size `2` => `"str[2]"`
+  etc.
+
+### String slices
+
+  String slice => `"str"`
+
+### Arrays
+
+ `[T; 1]` => `"[{abi_str(T)}; 1]"`
+ `[T; 2]` => `"[{abi_str(T)}; 2]"`
+etc.
+
+### Tuples
+
+ `()`      => `"()"`
+ `(T1)`    => `"({abi_str(T1)})"`
+ `(T1,T2)` => `"({abi_str(T1)}, {abi_str(T2)})"`
+etc.
+
+### Enums
+
+  `Option` enum with type parameter `T` => `"enum std::option::Option<{abi_str(T)}>"`
+  Enum without type parameters named `MyEnum` => `"enum MyEnum"`
+  Enum with type parameter `T1` named `MyEnum` => `"enum MyEnum<{abi_str(T1)}>"`
+  Enum with type parameters `T1`, `T2` named `MyEnum` in `my_module` => `"enum my_module::MyEnum<{abi_str(T1)},{abi_str(T2)}>"`
+
+### Structs
+
+  `Vec` struct with type parameter `T` => `"struct std::vec::Vec<{abi_str(T)}>"`
+  Struct without type parameters named `MyStruct` => `"struct MyStruct"`
+  Struct with type parameter `T1` named `MyStruct` => `"struct MyStruct<{abi_str(T1)}>"`
+  Struct with type parameters `T1`, `T2` named `MyStruct` in `my_module` => `"struct my_module::MyStruct<{abi_str(T1)},{abi_str(T2)}>"`
+
+### Generic Type Parameter
+
+ Generic type parameter `T` if root type => `"generic T"`
+ Generic type parameter `T` if not root type => `"T"` as in `"struct MyStruct<T>"`
+
+### Complex examples composition
+
+ Tuple of array and `u64` => `"([u64,1]; u64)"`
+ Array of `Option<u64>`=> `"[enum std::option::Option<u64>; 3]"`
+ Struct with tuple type parameter => `"struct my_module::MyStruct<(u64, u64)>"`

--- a/src/abi/index.md
+++ b/src/abi/index.md
@@ -6,3 +6,4 @@ This document describes and specifies the ABI (Application Binary Interface) of 
 - [Receipts](./receipts.md)
 - [Function Selector Encoding](./fn-selector-encoding.md)
 - [Argument Encoding](./argument-encoding.md)
+- [Hash Based Ids](./hash-based-ids.md)

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -32,8 +32,9 @@ we define the following expressions:
 
 The ABI of a contract is represented as a JSON object containing the following properties:
 
-- `"specVersion"`: a string representing the version pointing to this document versioning. When `specVersion` is incremented, it will usually incur an increment in `abiVersion` too.
-- `"abiVersion"`: a string representing the version of the implementation of this document `abiVersion` may be incremented while `specVersion` is not.
+- `"specVersion"`: a string representing the version pointing to this document versioning. `specVersion` enables the reader of the JSON ABI to find the correct specification for that file, this can be done by comparing it to value in [spec version](#spec-version). `specVersion` may change without a change in `abiVersion` for instance if the hash based ids computation is altered.
+- `"abiVersion"`: a string representing the version of the implementation of this document, `abiVersion` exists to be used by the SDKs so they can parse a JSON ABI based on its `abiVersion`.
+- `"encoding"`: a string representing the version of the `ABIEncode` and `ABIDecode` used in this program.
 - `"programType"`: a string that can be `"script"`, `"contract"`, `"predicate"`, `"library"`. This is used by the SDK to generate types without having to manually specify the program type.
 - `"types"`: an array describing all the _type declarations_ used (or transitively used) in the ABI. Each _type declaration_ is a JSON object that contains the following properties:
   - `"typeId"`: a unique string hash based ID. Generated as specified in [Hash Based Ids](./hash-based-ids.md).

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -2,6 +2,12 @@
 
 The JSON of an ABI is the human-readable representation of the interface of a Sway contract.
 
+## Spec Version
+
+Current `specVersion` is `1.0.0`
+
+The version above should be updated each time this spec changes and the ABI generator should be updated with the new changes along with an increment in the spec version.
+
 ## Notation
 
 Before describing the format of the JSON ABI, we provide some definitions that will make the JSON ABI spec easier to read.
@@ -26,51 +32,54 @@ we define the following expressions:
 
 The ABI of a contract is represented as a JSON object containing the following properties:
 
-- `"types`": an array describing all the _type declarations_ used (or transitively used) in the ABI. Each _type declaration_ is a JSON object that contains the following properties:
-  - `"typeId"`: a unique integer ID.
+- `"specVersion"`: a string representing the version pointing to this document versioning. When `specVersion` is incremented, it will usually incur an increment in `abiVersion` too.
+- `"abiVersion"`: a string representing the version of the implementation of this document `abiVersion` may be incremented while `specVersion` is not.
+- `"programType"`: a string that can be `"script"`, `"contract"`, `"predicate"`, `"library"`. This is used by the SDK to generate types without having to manually specify the program type.
+- `"types"`: an array describing all the _type declarations_ used (or transitively used) in the ABI. Each _type declaration_ is a JSON object that contains the following properties:
+  - `"typeId"`: a unique string hash based ID. Generated as specified in [Hash Based Ids](./hash-based-ids.md).
   - `"type"`: a string representation of the _type declaration_. The section [JSON ABI Format for Each Possible Type Declaration](#json-abi-format-for-each-possible-type-declaration) specifies the format for each possible type.
   - `"components"`: an array of the components of a given type, if any, and `null` otherwise. Each component is a _type application_ represented as a JSON object that contains the following properties:
     - `"name"`: the name of the component.
-    - `"type"`: the _type declaration_ ID of the type of the component.
+    - `"type"`: the _type declaration_ hash based ID of the type of the component.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the component, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ ID of the type of the _type argument_.
+      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"typeParameters"`: an array of type IDs of the _type parameters_ of the type, if the type is generic, and `null` otherwise. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).
+  - `"typeParameters"`: an array of type hash based IDs of the _type parameters_ of the type, if the type is generic, and `null` otherwise. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).
 - `"functions`": an array describing all the functions in the ABI. Each function is a JSON object that contains the following properties:
   - `"name"`: the name of the function
   - `"inputs"`: an array of objects that represents the inputs to the function (i.e. its parameters). Each input is a _type application_ represented as a JSON object that contains the following properties:
     - `"name"`: the name of the input.
-    - `"type"`: the _type declaration_ ID of the type of the input.
+    - `"type"`: the _type declaration_ hash based ID of the type of the input.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the input, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ ID of the type of the _type argument_.
+      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
   - `"output"`: an object representing the output of the function (i.e. its return value). The output is a _type application_, which is a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ ID of the type of the output.
+    - `"type"`: the _type declaration_ hash based ID of the type of the output.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the output, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ ID of the type of the _type argument_.
+      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
   - `"attributes"`: an optional array of _attributes_. Each _attribute_ is explained in the [dedicated section](#attributes-semantics) and is represented as a JSON object that contains the following properties:
     - `"name"`: the name of the attribute.
     - `"arguments"`: an array of attribute arguments.
 - `"loggedTypes"`: an array describing all instances of [`log`](../fuel-vm/instruction-set.md#log-log-event) or [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
-  - `"logId"`: a unique integer ID. The [`log`](../fuel-vm/instruction-set.md#log-log-event) and [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
+  - `"logId"`: a string containing the 64bit hash based decimal ID calculated from the first 8 bytes of the `sha256` of a string that represents the type logged as defined in [Hash Based Ids](./hash-based-ids.md). The [`log`](../fuel-vm/instruction-set.md#log-log-event) and [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
   - `"loggedType"`: a _type application_ represented as a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ ID of the type of the value being logged.
+    - `"type"`: the _type declaration_ hash based ID of the type of the value being logged.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the value being logged, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ ID of the type of the _type argument_.
+      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
 - `"messagesTypes"`: an array describing all instances of [`smo`](../fuel-vm/instruction-set.md#smo-send-message-to-output) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
   - `"messageDataType"`: a _type application_ represented as a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ ID of the type of the message data being sent.
+    - `"type"`: the _type declaration_ hash based ID of the type of the message data being sent.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the message data being sent, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ ID of the type of the _type argument_.
+      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
 - `"configurables"`: an array describing all `configurable` variables used in the contract. Each `configurable` variable is represented as a JSON object that contains the following properties:
   - `"name"`: the name of the `configurable` variable.
   - `"configurableType"`: a _type application_ represented as a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ ID of the type of the `configurable` variable.
+    - `"type"`: the _type declaration_ hash based ID of the type of the `configurable` variable.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the `configurable` variable, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ ID of the type of the _type argument_.
+      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
   - `"offset"`: the specific offset within the contract's bytecode, in bytes, to the data section entry for the `configurable` variable.
 
@@ -104,25 +113,25 @@ the JSON representation of this ABI looks like:
 {
   "types": [
     {
-      "typeId": 0,
+      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
       "type": "()",
       "components": [],
       "typeParameters": null
     },
     {
-      "typeId": 1,
+      "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
       "type": "b256",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 2,
+      "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
       "type": "bool",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 3,
+      "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
       "type": "u64",
       "components": null,
       "typeParameters": null
@@ -133,13 +142,13 @@ the JSON representation of this ABI looks like:
       "inputs": [
         {
           "name": "arg",
-          "type": 3,
+          "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
           "typeArguments": null
         }
       ],
       "name": "first_function",
       "output": {
-        "type": 2,
+        "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
         "typeArguments": null
       }
     },
@@ -147,13 +156,13 @@ the JSON representation of this ABI looks like:
       "inputs": [
         {
           "name": "arg",
-          "type": 1,
+          "type": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
           "typeArguments": null
         }
       ],
       "name": "second_function",
       "output": {
-        "type": 0,
+        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
         "typeArguments": null
       }
     }
@@ -170,7 +179,7 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
   "type": "()",
   "components": null,
   "typeParameters": null
@@ -181,7 +190,7 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
   "type": "bool",
   "components": null,
   "typeParameters": null
@@ -192,7 +201,7 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "typeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
   "type": "u8",
   "components": null,
   "typeParameters": null
@@ -203,7 +212,7 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "typeId": "29881aad8730c5ab11d275376323d8e4ff4179aae8ccb6c13fe4902137e162ef",
   "type": "u16",
   "components": null,
   "typeParameters": null
@@ -214,7 +223,7 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "typeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc",
   "type": "u32",
   "components": null,
   "typeParameters": null
@@ -225,7 +234,7 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
   "type": "u64",
   "components": null,
   "typeParameters": null
@@ -236,7 +245,7 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
   "type": "b256",
   "components": null,
   "typeParameters": null
@@ -474,99 +483,99 @@ its JSON representation would look like:
 {
   "types": [
     {
-      "typeId": 0,
+      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
       "type": "()",
       "components": [],
       "typeParameters": null
     },
     {
-      "typeId": 1,
+      "typeId": "625531542be70834dd127e771101ac1014111718451bfae996d97abe700c66a5",
       "type": "(_, _, _)",
       "components": [
         {
           "name": "__tuple_element",
-          "type": 2,
+          "type": "40c357685306e593eb4c4154377425853a7387ac5a6962d1d9198081a011d64a",
           "typeArguments": null
         },
         {
           "name": "__tuple_element",
-          "type": 4,
+          "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
           "typeArguments": null
         },
         {
           "name": "__tuple_element",
-          "type": 3,
+          "type": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 2,
+      "typeId": "40c357685306e593eb4c4154377425853a7387ac5a6962d1d9198081a011d64a",
       "type": "[_; 3]",
       "components": [
         {
           "name": "__array_element",
-          "type": 6,
+          "type": "84877f6e98274b9e4721db68b4c0bdb9e52b8e9572c5bd7811c07a41ced882c7",
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 3,
+      "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
       "type": "b256",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 4,
+      "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
       "type": "bool",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 5,
+      "typeId": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
       "type": "enum MyEnum",
       "components": [
         {
           "name": "Foo",
-          "type": 8,
+          "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
           "typeArguments": null
         },
         {
           "name": "Bar",
-          "type": 4,
+          "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 6,
+      "typeId": "84877f6e98274b9e4721db68b4c0bdb9e52b8e9572c5bd7811c07a41ced882c7",
       "type": "str[5]",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 7,
+      "typeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
       "type": "struct MyStruct",
       "components": [
         {
           "name": "bim",
-          "type": 8,
+          "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
           "typeArguments": null
         },
         {
           "name": "bam",
-          "type": 5,
+          "type": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 8,
+      "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
       "type": "u64",
       "components": null,
       "typeParameters": null
@@ -577,18 +586,18 @@ its JSON representation would look like:
       "inputs": [
         {
           "name": "arg1",
-          "type": 1,
+          "type": "625531542be70834dd127e771101ac1014111718451bfae996d97abe700c66a5",
           "typeArguments": null
         },
         {
           "name": "arg2",
-          "type": 7,
+          "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
           "typeArguments": null
         }
       ],
       "name": "complex_function",
       "output": {
-        "type": 0,
+        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
         "typeArguments": null
       },
       "attributes": [
@@ -636,72 +645,72 @@ its JSON representation would look like:
 {
   "types": [
     {
-      "typeId": 0,
+      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
       "type": "()",
       "components": [],
       "typeParameters": null
     },
     {
-      "typeId": 1,
+      "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
       "type": "b256",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 2,
+      "typeId": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
       "type": "enum MyEnum",
       "components": [
         {
           "name": "Foo",
-          "type": 3,
+          "type": "8b8c08c464656c9a4b876c13199929c5ceb37ff6c927eaeefd756c12278e98c5",
           "typeArguments": null
         },
         {
           "name": "Bar",
-          "type": 4,
+          "type": "037c28680d4d1fe36b9eea25fdf0b1b158fc70d022e376a17fd2cf045b416525",
           "typeArguments": null
         }
       ],
-      "typeParameters": [3, 4]
+      "typeParameters": ["8b8c08c464656c9a4b876c13199929c5ceb37ff6c927eaeefd756c12278e98c5", "037c28680d4d1fe36b9eea25fdf0b1b158fc70d022e376a17fd2cf045b416525"]
     },
     {
-      "typeId": 3,
+      "typeId": "8b8c08c464656c9a4b876c13199929c5ceb37ff6c927eaeefd756c12278e98c5",
       "type": "generic T",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 4,
+      "typeId": "037c28680d4d1fe36b9eea25fdf0b1b158fc70d022e376a17fd2cf045b416525",
       "type": "generic U",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 5,
+      "typeId": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
       "type": "generic W",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 6,
+      "typeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
       "type": "struct MyStruct",
       "components": [
         {
           "name": "bam",
-          "type": 2,
+          "type": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
           "typeArguments": [
             {
-              "type": 5,
+              "type": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
               "typeArguments": null
             },
             {
-              "type": 5,
+              "type": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
               "typeArguments": null
             }
           ]
         }
       ],
-      "typeParameters": [5]
+      "typeParameters": ["8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2"]
     }
   ],
   "functions": [
@@ -709,10 +718,10 @@ its JSON representation would look like:
       "inputs": [
         {
           "name": "arg1",
-          "type": 6,
+          "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
           "typeArguments": [
             {
-              "type": 1,
+              "type": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
               "typeArguments": null
             }
           ]
@@ -720,7 +729,7 @@ its JSON representation would look like:
       ],
       "name": "complex_function",
       "output": {
-        "type": 0,
+        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d ",
         "typeArguments": null
       }
     }
@@ -756,37 +765,37 @@ its JSON representation would look like:
 {
   "types": [
     {
-      "typeId": 0,
+      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
       "type": "()",
       "components": [],
       "typeParameters": null
     },
     {
-      "typeId": 1,
+      "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
       "type": "bool",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 2,
+      "typeId": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
       "type": "generic W",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 3,
+      "typeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
       "type": "struct MyStruct",
       "components": [
         {
           "name": "x",
-          "type": 2,
+          "type": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
           "typeArguments": null
         }
       ],
-      "typeParameters": [2]
+      "typeParameters": ["8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2"]
     },
     {
-      "typeId": 4,
+      "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
       "type": "u64",
       "components": null,
       "typeParameters": null
@@ -797,31 +806,31 @@ its JSON representation would look like:
       "inputs": [],
       "name": "logging",
       "output": {
-        "type": 0,
+        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
         "typeArguments": null
       }
     }
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "12896678128313068780",
       "loggedType": {
-        "type": 3,
+        "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
         "typeArguments": [
           {
-            "type": 4,
+            "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
             "typeArguments": null
           }
         ]
       }
     },
     {
-      "logId": 1,
+      "logId": "16383228984366451899",
       "loggedType": {
-        "type": 3,
+        "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
         "typeArguments": [
           {
-            "type": 1,
+            "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
             "typeArguments": null
           }
         ]
@@ -830,3 +839,8 @@ its JSON representation would look like:
   ]
 }
 ```
+
+The `logId`s are calculated from:
+
+- First 8 bytes of `sha256("struct MyStruct<u64>")` => `"12896678128313068780"`
+- First 8 bytes of `sha256("struct MyStruct<bool>")` => `"16383228984366451899"`

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -4,7 +4,7 @@ The JSON of an ABI is the human-readable representation of the interface of a Sw
 
 ## Spec Version
 
-Current `specVersion` is `1.0.0`
+Current `specVersion` is `1.0`
 
 The version above should be updated each time this spec changes and the ABI generator should be updated with the new changes along with an increment in the spec version.
 

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -33,7 +33,7 @@ we define the following expressions:
 The ABI of a contract is represented as a JSON object containing the following properties:
 
 - `"specVersion"`: a string representing the version pointing to this document versioning. `specVersion` enables the reader of the JSON ABI to find the correct specification for that file, this can be done by comparing it to value in [spec version](#spec-version).
-- `"encoding"`: a string representing the version of the `ABIEncode` and `ABIDecode` used in this program.
+- `"encodingVersion"`: a string representing the version of the `ABIEncode` and `ABIDecode` used in this program.
 - `"programType"`: a string that can be `"script"`, `"contract"`, `"predicate"`, `"library"`. This is used by the SDK to generate types without having to manually specify the program type.
 - `"types"`: an array describing all the _type declarations_ used (or transitively used) in the ABI. Each _type declaration_ is a JSON object that contains the following properties:
   - `"typeId"`: a unique string hash based ID. Generated as specified in [Hash Based Ids](./hash-based-ids.md).

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -6,7 +6,7 @@ The JSON of an ABI is the human-readable representation of the interface of a Sw
 
 Current `specVersion` is `1.0`
 
-The version above should be updated each time this spec changes and the ABI generator should be updated with the new changes along with an increment in the spec version.
+The version above should be updated each time this spec changes and the JSON ABI generator should be updated with the new changes along with an increment in the spec version.
 
 ## Notation
 
@@ -32,8 +32,7 @@ we define the following expressions:
 
 The ABI of a contract is represented as a JSON object containing the following properties:
 
-- `"specVersion"`: a string representing the version pointing to this document versioning. `specVersion` enables the reader of the JSON ABI to find the correct specification for that file, this can be done by comparing it to value in [spec version](#spec-version). `specVersion` may change without a change in `abiVersion` for instance if the hash based ids computation is altered.
-- `"abiVersion"`: a string representing the version of the implementation of this document, `abiVersion` exists to be used by the SDKs so they can parse a JSON ABI based on its `abiVersion`.
+- `"specVersion"`: a string representing the version pointing to this document versioning. `specVersion` enables the reader of the JSON ABI to find the correct specification for that file, this can be done by comparing it to value in [spec version](#spec-version).
 - `"encoding"`: a string representing the version of the `ABIEncode` and `ABIDecode` used in this program.
 - `"programType"`: a string that can be `"script"`, `"contract"`, `"predicate"`, `"library"`. This is used by the SDK to generate types without having to manually specify the program type.
 - `"types"`: an array describing all the _type declarations_ used (or transitively used) in the ABI. Each _type declaration_ is a JSON object that contains the following properties:

--- a/src/fuel-vm/index.md
+++ b/src/fuel-vm/index.md
@@ -183,13 +183,13 @@ A call frame consists of the following, word-aligned:
 
 ## Access rights
 
-Only memory that has been allocated is accessible. 
-In other words, memory between highest-ever `$sp` value and current `$hp` 
-is inaccessible. Attempting to read or write 
-memory that has not been allocated will result in VM panic. 
-Similarly reads or writes that cross from the stack to the heap 
-will panic. Note that stack remains readable even after stack 
-frame has been shrunk. However, if the heap is afterwards expanded 
+Only memory that has been allocated is accessible.
+In other words, memory between highest-ever `$sp` value and current `$hp`
+is inaccessible. Attempting to read or write
+memory that has not been allocated will result in VM panic.
+Similarly reads or writes that cross from the stack to the heap
+will panic. Note that stack remains readable even after stack
+frame has been shrunk. However, if the heap is afterwards expanded
 to cover that area, the crossing read prohibition still remains,
 while all memory is accessible.
 


### PR DESCRIPTION

[#5151](https://github.com/FuelLabs/sway/issues/5151)
[#5952](https://github.com/FuelLabs/sway/issues/5952)
[#5954](https://github.com/FuelLabs/sway/issues/5954)

Adds specification for how hashes based ids are generated from a string representation of types.

Updates `json-abi-format.md` with versions, program type, and hash based ids.

### Before requesting review
- [x] I have reviewed the code myself

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Typescript SDK](https://github.com/FuelLabs/fuels-ts/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
