### PR TITLE
Adds concrete types distinction to JSON ABI.

### DIFF
--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -366,12 +366,6 @@ its JSON representation would look like:
       "metadataTypeId": 1,
     },
     {
-      "type": "[str[5]; 3]",
-      "concreteTypeId": "40c357685306e593eb4c4154377425853a7387ac5a6962d1d9198081a011d64a",
-      "metadataTypeId": 2,
-    },
-    ,
-    {
       "type": "str[5]",
       "concreteTypeId": "84877f6e98274b9e4721db68b4c0bdb9e52b8e9572c5bd7811c07a41ced882c7",
     },

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -23,7 +23,8 @@ fn baz(input1: Foo, input2: Bar<u64>); // an ABI function
 
 we define the following expressions:
 
-- _type declaration_: the declaration or definition of a type which can be generic. `struct Foo { .. }` and `struct Bar<T> { .. }` in the example above are both type declarations.
+- _type concrete declaration_: the declaration or definition of a type which can be generic. `struct Foo { .. }` and `struct Bar<T> { .. }` in the example above are both type declarations. Note that generic types may have multiple _type concrete declaration_.
+- _type metadata declaration_: the declaration or definition of a type which can be generic. `struct Foo { .. }` and `struct Bar<T> { .. }` in the example above are both type declarations. The metadata declaration contains component details about the type. And a single _type metadata declaration_ is generated per type, even for generic types.
 - _type application_: the application or use of a type. `Foo` and `Bar<u64>` in `fn baz(input1: Foo, input2: Bar<u64>);` in the example above are both applications of the type declarations `struct Foo { .. }` and `struct Bar<T> { .. }` respectively.
 - _type parameter_: a generic parameter used in a type declaration. `T` in `struct Bar<T>` in the example above is a type parameter.
 - _type argument_: an application of a type parameter used in a type application. `u64` in `input2: Bar<u64>` in the example above is a type argument.
@@ -35,52 +36,36 @@ The ABI of a contract is represented as a JSON object containing the following p
 - `"specVersion"`: a string representing the version pointing to this document versioning. `specVersion` enables the reader of the JSON ABI to find the correct specification for that file, this can be done by comparing it to value in [spec version](#spec-version).
 - `"encodingVersion"`: a string representing the version of the `ABIEncode` and `ABIDecode` used in this program.
 - `"programType"`: a string that can be `"script"`, `"contract"`, `"predicate"`, `"library"`. This is used by the SDK to generate types without having to manually specify the program type.
-- `"types"`: an array describing all the _type declarations_ used (or transitively used) in the ABI. Each _type declaration_ is a JSON object that contains the following properties:
-  - `"typeId"`: a unique string hash based ID. Generated as specified in [Hash Based Ids](./hash-based-ids.md).
-  - `"type"`: a string representation of the _type declaration_. The section [JSON ABI Format for Each Possible Type Declaration](#json-abi-format-for-each-possible-type-declaration) specifies the format for each possible type.
-  - `"components"`: an array of the components of a given type, if any, and `null` otherwise. Each component is a _type application_ represented as a JSON object that contains the following properties:
+- `"concreteTypes"`: an array describing all the _type concrete declarations_ used (or transitively used) in the ABI. Each _type concrete declaration_ is a JSON object that contains the following properties:
+  - `"type"`: a string representing the type, the `sha256` of this string generates the `concreteTypeId`.
+  - `"concreteTypeId"`: a unique string hash based ID. Generated as specified in [Hash Based Ids](./hash-based-ids.md).
+  - `"metadataTypeId"`: the the _type metadata declaration_ ID of this type, if the type metadata has components or is generic, otherwise non existent.
+  - `"typeArguments"`: an array of _type concrete declarations_ hash based IDs of the type parameters of the type, if the type is generic, otherwise non existent.
+- `"typesMetadata"`: an array describing all the _type metadata declarations_ used (or transitively used) in the ABI. Each _type metadata declaration_ is a JSON object that contains the following properties:
+  - `"type"`: a string representation of the _type metadata declaration_. The section [JSON ABI Format for Each Possible Metadata Type Declaration](#json-abi-format-for-each-possible-metadata-type-declaration) specifies the format for each possible type.
+  - `"metadataTypeId"`: a unique integer ID.
+  - `"components"`: an array of the components of a given type, if any, otherwise non existent. Each component is a _type application_ represented as a JSON object that contains the following properties:
     - `"name"`: the name of the component.
-    - `"type"`: the _type declaration_ hash based ID of the type of the component.
-    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the component, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
-      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"typeParameters"`: an array of type hash based IDs of the _type parameters_ of the type, if the type is generic, and `null` otherwise. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).
+    - `"typeId"`: the _type metadata declaration_ ID or _type concrete declaration_ hash based ID of the type of the component.
+    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the component, if the type is generic, otherwise non existent. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
+      - `"typeId"`: the _type metadata declaration_ ID or _type concrete declaration_ hash based ID of the type of the component.
+      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, otherwise non existent. The format of the elements of this array recursively follows the rules described in this section.
+  - `"typeParameters"`: an array of _type metadata declaration_ ID of the _type parameters_ of the type, if the type is generic, otherwise non existent. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).
 - `"functions`": an array describing all the functions in the ABI. Each function is a JSON object that contains the following properties:
   - `"name"`: the name of the function
   - `"inputs"`: an array of objects that represents the inputs to the function (i.e. its parameters). Each input is a _type application_ represented as a JSON object that contains the following properties:
     - `"name"`: the name of the input.
-    - `"type"`: the _type declaration_ hash based ID of the type of the input.
-    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the input, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
-      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"output"`: an object representing the output of the function (i.e. its return value). The output is a _type application_, which is a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ hash based ID of the type of the output.
-    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the output, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
-      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
-  - `"attributes"`: an optional array of _attributes_. Each _attribute_ is explained in the [dedicated section](#attributes-semantics) and is represented as a JSON object that contains the following properties:
-    - `"name"`: the name of the attribute.
-    - `"arguments"`: an array of attribute arguments.
+    - `"concreteTypeId"`: the _type concrete declaration_ hash based ID of the type of the input.
+  - `"output"`: the _type concrete declaration_ hash based ID of the type being returned by the function.
 - `"loggedTypes"`: an array describing all instances of [`log`](../fuel-vm/instruction-set.md#log-log-event) or [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
   - `"logId"`: a string containing the 64bit hash based decimal ID calculated from the first 8 bytes of the `sha256` of a string that represents the type logged as defined in [Hash Based Ids](./hash-based-ids.md). The [`log`](../fuel-vm/instruction-set.md#log-log-event) and [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
-  - `"loggedType"`: a _type application_ represented as a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ hash based ID of the type of the value being logged.
-    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the value being logged, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
-      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
+  - `"loggedType"`: the _type concrete declaration_ hash based ID of the value being logged.
 - `"messagesTypes"`: an array describing all instances of [`smo`](../fuel-vm/instruction-set.md#smo-send-message-to-output) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
-  - `"messageDataType"`: a _type application_ represented as a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ hash based ID of the type of the message data being sent.
-    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the message data being sent, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
-      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
+  - `"message_id"`: a unique string ID.
+  - `"messageDataType"`: the _type concrete declaration_ hash based ID of the message data being sent.
 - `"configurables"`: an array describing all `configurable` variables used in the contract. Each `configurable` variable is represented as a JSON object that contains the following properties:
   - `"name"`: the name of the `configurable` variable.
-  - `"configurableType"`: a _type application_ represented as a JSON object that contains the following properties:
-    - `"type"`: the _type declaration_ hash based ID of the type of the `configurable` variable.
-    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the `configurable` variable, if the type is generic, and `null` otherwise. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"type"`: the _type declaration_ hash based ID of the type of the _type argument_.
-      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, and `null` otherwise. The format of the elements of this array recursively follows the rules described in this section.
+  - `"configurableType"`: the _type concrete declaration_ hash based ID of the type of the `configurable` variable.
   - `"offset"`: the specific offset within the contract's bytecode, in bytes, to the data section entry for the `configurable` variable.
 
 > **Note**: This JSON should be both human-readable and parsable by the tooling around the FuelVM and the Sway programming language. There is a detailed specification for the binary encoding backing this readable descriptor. The [Function Selector Encoding](./fn-selector-encoding.md) section specifies the encoding for the function being selected to be executed and each of the argument types.
@@ -111,164 +96,72 @@ the JSON representation of this ABI looks like:
 
 ```json
 {
-  "types": [
+  "concreteTypes": [
     {
-      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-      "type": "()",
-      "components": [],
-      "typeParameters": null
-    },
-    {
-      "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
-      "type": "b256",
-      "components": null,
-      "typeParameters": null
-    },
-    {
-      "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
-      "type": "bool",
-      "components": null,
-      "typeParameters": null
-    },
-    {
-      "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
       "type": "u64",
-      "components": null,
-      "typeParameters": null
+      "concreteTypeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0"
+    },
+    {
+      "type": "b256",
+      "concreteTypeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b"
+    },
+    {
+      "type": "bool",
+      "concreteTypeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903"
+    },
+    {
+      "type": "()",
+      "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
     }
   ],
+  "typesMetadata": [],
   "functions": [
     {
       "inputs": [
         {
           "name": "arg",
-          "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-          "typeArguments": null
+          "concreteTypeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0"
         }
       ],
       "name": "first_function",
-      "output": {
-        "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
-        "typeArguments": null
-      }
+      "output": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903"
     },
     {
       "inputs": [
         {
           "name": "arg",
-          "type": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
-          "typeArguments": null
+          "concreteTypeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b"
         }
       ],
       "name": "second_function",
-      "output": {
-        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-        "typeArguments": null
-      }
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
     }
   ],
   "loggedTypes": []
 }
 ```
 
-## JSON ABI Format for Each Possible Type Declaration
+## JSON ABI Format for Each Possible Metadata Type Declaration
 
-Below is a list of the JSON ABI formats for each possible type declaration:
-
-### `()`
-
-```json
-{
-  "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-  "type": "()",
-  "components": null,
-  "typeParameters": null
-}
-```
-
-### `bool`
-
-```json
-{
-  "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
-  "type": "bool",
-  "components": null,
-  "typeParameters": null
-}
-```
-
-### `u8`
-
-```json
-{
-  "typeId": "c89951a24c6ca28c13fd1cfdc646b2b656d69e61a92b91023be7eb58eb914b6b",
-  "type": "u8",
-  "components": null,
-  "typeParameters": null
-}
-```
-
-### `u16`
-
-```json
-{
-  "typeId": "29881aad8730c5ab11d275376323d8e4ff4179aae8ccb6c13fe4902137e162ef",
-  "type": "u16",
-  "components": null,
-  "typeParameters": null
-}
-```
-
-### `u32`
-
-```json
-{
-  "typeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc",
-  "type": "u32",
-  "components": null,
-  "typeParameters": null
-}
-```
-
-### `u64`
-
-```json
-{
-  "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-  "type": "u64",
-  "components": null,
-  "typeParameters": null
-}
-```
-
-### `b256`
-
-```json
-{
-  "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
-  "type": "b256",
-  "components": null,
-  "typeParameters": null
-}
-```
+Below is a list of the JSON ABI formats for each possible metadata type declaration:
 
 ### `struct`
 
 ```json
 {
-  "typeId": <id>,
+  "metadataTypeId": <id>,
   "type": "struct <struct_name>",
   "components": [
     {
       "name": "<field1_name>",
-      "type": <field1_type_id>,
+      "typeId": "<field1_type_id>",
       "typeArguments": [
         {
-          "type": <type_arg1_type_id>,
+          "typeId": "<type_arg1_type_id>",
           "typeArguments": ...
         },
         {
-          "type": <type_arg2_type_id>,
+          "typeId": "<type_arg2_type_id>",
           "typeArguments": ...
         },
         ...
@@ -276,14 +169,14 @@ Below is a list of the JSON ABI formats for each possible type declaration:
     },
     {
       "name": "<field2_name>",
-      "type": <field2_type_id>,
+      "typeId": "<field2_type_id>",
       "typeArguments": [
         {
-          "type": <type_arg1_type_id>,
+          "typeId": "<type_arg1_type_id>",
           "typeArguments": ...
         },
         {
-          "type": <type_arg2_type_id>,
+          "typeId": "<type_arg2_type_id>",
           "typeArguments": ...
         },
         ...
@@ -303,19 +196,19 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "metadataTypeId": <id>,
   "type": "enum <enum_name>",
   "components": [
     {
       "name": "<variant1_name>",
-      "type": <variant1_type_id>,
+      "typeId": "<variant1_type_id>",
       "typeArguments": [
         {
-          "type": <type_arg1_type_id>,
+          "typeId": "<type_arg1_type_id>",
           "typeArguments": ...
         },
         {
-          "type": <type_arg2_type_id>,
+          "typeId": "<type_arg2_type_id>",
           "typeArguments": ...
         },
         ...
@@ -323,14 +216,14 @@ Below is a list of the JSON ABI formats for each possible type declaration:
     },
     {
       "name": "<variant2_name>",
-      "type": <variant2_type_id>,
+      "typeId": "<variant2_type_id>",
       "typeArguments": [
         {
-          "type": <type_arg1_type_id>,
+          "typeId": "<type_arg1_type_id>",
           "typeArguments": ...
         },
         {
-          "type": <type_arg2_type_id>,
+          "typeId": "<type_arg2_type_id>",
           "typeArguments": ...
         },
         ...
@@ -346,49 +239,34 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 }
 ```
 
-### `str[<n>]`
-
-```json
-{
-  "typeId": <id>,
-  "type": "str[<n>]",
-  "components": null,
-  "typeParameters": null
-}
-```
-
-`<n>` is the length of the string.
-
 ### `array`
 
 ```json
 {
-  "typeId": <id>,
+  "metadataTypeId": <id>,
   "type": "[_; <n>]",
   "components": [
     {
       "name": "__array_element",
-      "type": "<element_type>",
+      "typeId": "<element_type>",
       "typeArguments": ...
     }
     {
       "name": "__array_element",
-      "type": <element_type_id>,
+      "typeId": "<element_type_id>",
       "typeArguments": [
         {
-          "type": <type_arg1_type_id>,
+          "typeId": "<type_arg1_type_id>",
           "typeArguments": ...
         },
         {
-          "type": <type_arg2_type_id>,
+          "typeId": "<type_arg2_type_id>",
           "typeArguments": ...
         },
         ...
       ]
     },
-
-  ],
-  "typeParameters": null
+  ]
 }
 ```
 
@@ -398,19 +276,19 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
+  "metadataTypeId": <id>,
   "type": "(_, _, ...)",
   "components": [
     {
       "name": "__tuple_element",
-      "type": <field1_type_id>,
+      "typeId": "<field1_type_id>",
       "typeArguments": [
         {
-          "type": <type_arg1_type_id>,
+          "typeId": "<type_arg1_type_id>",
           "typeArguments": ...
         },
         {
-          "type": <type_arg2_type_id>,
+          "typeId": "<type_arg2_type_id>",
           "typeArguments": ...
         },
         ...
@@ -418,22 +296,21 @@ Below is a list of the JSON ABI formats for each possible type declaration:
     },
     {
       "name": "__tuple_element",
-      "type": <field2_type_id>,
+      "typeId": "<field2_type_id>",
       "typeArguments": [
         {
-          "type": <type_arg1_type_id>,
+          "typeId": "<type_arg1_type_id>",
           "typeArguments": ...
         },
         {
-          "type": <type_arg2_type_id>,
+          "typeId": "<type_arg2_type_id>",
           "typeArguments": ...
         },
         ...
       ]
     },
     ...
-  ],
-  "typeParameters": null
+  ]
 }
 ```
 
@@ -441,10 +318,8 @@ Below is a list of the JSON ABI formats for each possible type declaration:
 
 ```json
 {
-  "typeId": <id>,
-  "type": "generic <name>",
-  "components": null,
-  "typeParameters": null
+  "metadataTypeId": <id>,
+  "type": "generic <name>"
 }
 ```
 
@@ -481,125 +356,116 @@ its JSON representation would look like:
 
 ```json
 {
-  "types": [
+  "concreteTypes": [
     {
-      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-      "type": "()",
-      "components": [],
-      "typeParameters": null
+      "type": "([str[5]; 3], bool, b256)",
+      "concreteTypeId": "625531542be70834dd127e771101ac1014111718451bfae996d97abe700c66a5",
+      "metadataTypeId": 1,
     },
     {
-      "typeId": "625531542be70834dd127e771101ac1014111718451bfae996d97abe700c66a5",
+      "type": "[str[5]; 3]",
+      "concreteTypeId": "40c357685306e593eb4c4154377425853a7387ac5a6962d1d9198081a011d64a",
+      "metadataTypeId": 2,
+    },
+    ,
+    {
+      "type": "str[5]",
+      "concreteTypeId": "84877f6e98274b9e4721db68b4c0bdb9e52b8e9572c5bd7811c07a41ced882c7",
+    },
+    {
+      "type": "struct MyStruct",
+      "concreteTypeId": "392d58c694d2d91f3025f2bccfadacf2a105936f5da881b0899185d49f264522",
+      "metadataTypeId": 4,
+    },
+    {
+      "type": "u64",
+      "concreteTypeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0"
+    },
+    {
+      "type": "b256",
+      "concreteTypeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b"
+    },
+    {
+      "type": "bool",
+      "concreteTypeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903"
+    },
+    {
+      "type": "()",
+      "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
+    }
+  ],
+  "typesMetadata": [
+    {
+      "metadataTypeId": 1,
       "type": "(_, _, _)",
       "components": [
         {
           "name": "__tuple_element",
-          "type": "40c357685306e593eb4c4154377425853a7387ac5a6962d1d9198081a011d64a",
-          "typeArguments": null
+          "typeId": "2",
         },
         {
           "name": "__tuple_element",
-          "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
-          "typeArguments": null
+          "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
         },
         {
           "name": "__tuple_element",
-          "type": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
-          "typeArguments": null
+          "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
         }
-      ],
-      "typeParameters": null
+      ]
     },
     {
-      "typeId": "40c357685306e593eb4c4154377425853a7387ac5a6962d1d9198081a011d64a",
+      "metadataTypeId": 2,
       "type": "[_; 3]",
       "components": [
         {
           "name": "__array_element",
-          "type": "84877f6e98274b9e4721db68b4c0bdb9e52b8e9572c5bd7811c07a41ced882c7",
-          "typeArguments": null
+          "typeId": "84877f6e98274b9e4721db68b4c0bdb9e52b8e9572c5bd7811c07a41ced882c7",
         }
-      ],
-      "typeParameters": null
+      ]
     },
     {
-      "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
-      "type": "b256",
-      "components": null,
-      "typeParameters": null
-    },
-    {
-      "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
-      "type": "bool",
-      "components": null,
-      "typeParameters": null
-    },
-    {
-      "typeId": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
+      "metadataTypeId": 3,
       "type": "enum MyEnum",
       "components": [
         {
           "name": "Foo",
-          "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-          "typeArguments": null
+          "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
         },
         {
           "name": "Bar",
-          "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
-          "typeArguments": null
+          "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
         }
-      ],
-      "typeParameters": null
+      ]
     },
     {
-      "typeId": "84877f6e98274b9e4721db68b4c0bdb9e52b8e9572c5bd7811c07a41ced882c7",
-      "type": "str[5]",
-      "components": null,
-      "typeParameters": null
-    },
-    {
-      "typeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
+      "metadataTypeId": 4,
       "type": "struct MyStruct",
       "components": [
         {
           "name": "bim",
-          "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-          "typeArguments": null
+          "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
         },
         {
           "name": "bam",
-          "type": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
-          "typeArguments": null
+          "typeId": "3",
         }
-      ],
-      "typeParameters": null
+      ]
     },
-    {
-      "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-      "type": "u64",
-      "components": null,
-      "typeParameters": null
-    }
   ],
   "functions": [
     {
       "inputs": [
         {
           "name": "arg1",
-          "type": "625531542be70834dd127e771101ac1014111718451bfae996d97abe700c66a5",
-          "typeArguments": null
+          "concreteTypeId": "625531542be70834dd127e771101ac1014111718451bfae996d97abe700c66a5",
         },
         {
           "name": "arg2",
-          "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
-          "typeArguments": null
+          "concreteTypeId": "392d58c694d2d91f3025f2bccfadacf2a105936f5da881b0899185d49f264522"
         }
       ],
       "name": "complex_function",
-      "output": {
-        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-        "typeArguments": null
-      },
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
       "attributes": [
         {
           "name": "doc-comment",
@@ -643,74 +509,70 @@ its JSON representation would look like:
 
 ```json
 {
-  "types": [
+  "concreteTypes": [
     {
-      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-      "type": "()",
-      "components": [],
-      "typeParameters": null
+      "type": "struct MyStruct<b256>",
+      "concreteTypeId": "3ddd5c1768dd7869663dc2f868ea8a8ce68bd6064244dbc4286e2c921c8ce962",
+      "metadataTypeId": 5,
+      "typeArguments": [
+        "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b"
+      ]
     },
     {
-      "typeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
       "type": "b256",
-      "components": null,
-      "typeParameters": null
+      "concreteTypeId": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
     },
     {
-      "typeId": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
+      "type": "()",
+      "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
+    }
+  ],
+  "typesMetadata": [
+    {
+      "metadataTypeId": 1,
       "type": "enum MyEnum",
       "components": [
         {
           "name": "Foo",
-          "type": "8b8c08c464656c9a4b876c13199929c5ceb37ff6c927eaeefd756c12278e98c5",
-          "typeArguments": null
+          "type": 2,
         },
         {
           "name": "Bar",
-          "type": "037c28680d4d1fe36b9eea25fdf0b1b158fc70d022e376a17fd2cf045b416525",
-          "typeArguments": null
+          "type": 3,
         }
       ],
-      "typeParameters": ["8b8c08c464656c9a4b876c13199929c5ceb37ff6c927eaeefd756c12278e98c5", "037c28680d4d1fe36b9eea25fdf0b1b158fc70d022e376a17fd2cf045b416525"]
+      "typeParameters": [2, 3]
     },
     {
-      "typeId": "8b8c08c464656c9a4b876c13199929c5ceb37ff6c927eaeefd756c12278e98c5",
+      "metadataTypeId": 2,
       "type": "generic T",
-      "components": null,
-      "typeParameters": null
     },
     {
-      "typeId": "037c28680d4d1fe36b9eea25fdf0b1b158fc70d022e376a17fd2cf045b416525",
+      "metadataTypeId": 3,
       "type": "generic U",
-      "components": null,
-      "typeParameters": null
     },
     {
-      "typeId": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
+      "metadataTypeId": 4,
       "type": "generic W",
-      "components": null,
-      "typeParameters": null
     },
     {
-      "typeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
+      "metadataTypeId": 5,
       "type": "struct MyStruct",
       "components": [
         {
           "name": "bam",
-          "type": "83ffcfb3310e26adc9af12bd7f86d89f473ec49f37e929ef07d8b2b99cc39b30",
+          "type": 1,
           "typeArguments": [
             {
-              "type": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
-              "typeArguments": null
+              "typeId": "4",
             },
             {
-              "type": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
-              "typeArguments": null
+              "typeId": "4",
             }
           ]
         }
       ],
-      "typeParameters": ["8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2"]
+      "typeParameters": [4]
     }
   ],
   "functions": [
@@ -718,20 +580,11 @@ its JSON representation would look like:
       "inputs": [
         {
           "name": "arg1",
-          "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
-          "typeArguments": [
-            {
-              "type": "7c5ee1cecf5f8eacd1284feb5f0bf2bdea533a51e2f0c9aabe9236d335989f3b",
-              "typeArguments": null
-            }
-          ]
+          "concreteTypeId": "3ddd5c1768dd7869663dc2f868ea8a8ce68bd6064244dbc4286e2c921c8ce962"
         }
       ],
       "name": "complex_function",
-      "output": {
-        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d ",
-        "typeArguments": null
-      }
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
     }
   ],
   "loggedTypes": []
@@ -763,84 +616,75 @@ its JSON representation would look like:
 
 ```json
 {
-  "types": [
-    {
-      "typeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-      "type": "()",
-      "components": [],
-      "typeParameters": null
+  "concreteTypes": [
+    {      
+      "type": "struct MyStruct<bool>",
+      "concreteTypeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
+      "metadataTypeId": 1,
+      "typeArguments": [
+        "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903"
+      ]
     },
-    {
-      "typeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
+    {      
+      "type": "struct MyStruct<u64>",
+      "concreteTypeId": "b2fa346d9ca66ceca61951a27dba2977b2a82b8aa8600670604f286a1393dffe",
+      "metadataTypeId": 1,
+      "typeArguments": [
+        "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0"
+      ]
+    },
+    {      
       "type": "bool",
-      "components": null,
-      "typeParameters": null
+      "concreteTypeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
+    },
+    {      
+      "type": "u64",
+      "concreteTypeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
     },
     {
-      "typeId": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
-      "type": "generic W",
-      "components": null,
-      "typeParameters": null
-    },
+      "type": "()",
+      "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
+    }
+  ],
+  "typesMetadata": [
     {
-      "typeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
+      "metadataTypeId": 1,
       "type": "struct MyStruct",
       "components": [
         {
           "name": "x",
-          "type": "8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2",
+          "typeId": "2",
           "typeArguments": null
         }
       ],
-      "typeParameters": ["8481c239b53404729cdfbc37227da838ccb68c90cfa0412aeecd0552b73ef5d2"]
+      "typeParameters": [2]
     },
     {
-      "typeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-      "type": "u64",
-      "components": null,
-      "typeParameters": null
-    }
+      "metadataTypeId": 2,
+      "type": "generic W",
+    },
   ],
   "functions": [
     {
       "inputs": [],
       "name": "logging",
-      "output": {
-        "type": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
-        "typeArguments": null
-      }
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
     }
   ],
   "loggedTypes": [
     {
       "logId": "12896678128313068780",
-      "loggedType": {
-        "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
-        "typeArguments": [
-          {
-            "type": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
-            "typeArguments": null
-          }
-        ]
-      }
+      "loggedType": "b2fa346d9ca66ceca61951a27dba2977b2a82b8aa8600670604f286a1393dffe"
     },
     {
       "logId": "16383228984366451899",
-      "loggedType": {
-        "type": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389",
-        "typeArguments": [
-          {
-            "type": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
-            "typeArguments": null
-          }
-        ]
-      }
+      "loggedType": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389"
     }
   ]
 }
 ```
 
-The `logId`s are calculated from:
+The `logIds` are calculated from:
 
-- First 8 bytes of `sha256("struct MyStruct<u64>")` => `"12896678128313068780"`
-- First 8 bytes of `sha256("struct MyStruct<bool>")` => `"16383228984366451899"`
+- First 8 bytes of `sha256("struct MyStruct<u64>")` => "12896678128313068780"
+- First 8 bytes of `sha256("struct MyStruct<bool>")` => "16383228984366451899"

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -46,9 +46,9 @@ The ABI of a contract is represented as a JSON object containing the following p
   - `"metadataTypeId"`: a unique integer ID.
   - `"components"`: an array of the components of a given type, if any, otherwise non existent. Each component is a _type application_ represented as a JSON object that contains the following properties:
     - `"name"`: the name of the component.
-    - `"typeId"`: the _type metadata declaration_ ID or _type concrete declaration_ hash based ID of the type of the component.
+    - `"typeId"`: the _type metadata declaration_ ID (number) or _type concrete declaration_ hash based ID (string) of the type of the component.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the component, if the type is generic, otherwise non existent. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
-      - `"typeId"`: the _type metadata declaration_ ID or _type concrete declaration_ hash based ID of the type of the component.
+      - `"typeId"`: the _type metadata declaration_ ID (number) or _type concrete declaration_ hash based ID (string) of the type of the component.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, otherwise non existent. The format of the elements of this array recursively follows the rules described in this section.
   - `"typeParameters"`: an array of _type metadata declaration_ ID of the _type parameters_ of the type, if the type is generic, otherwise non existent. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).
 - `"functions`": an array describing all the functions in the ABI. Each function is a JSON object that contains the following properties:
@@ -57,15 +57,18 @@ The ABI of a contract is represented as a JSON object containing the following p
     - `"name"`: the name of the input.
     - `"concreteTypeId"`: the _type concrete declaration_ hash based ID of the type of the input.
   - `"output"`: the _type concrete declaration_ hash based ID of the type being returned by the function.
+  - `"attributes"`: an optional array of _attributes_. Each _attribute_ is explained in the [dedicated section](#attributes-semantics) and is represented as a JSON object that contains the following properties:
+    - `"name"`: the name of the attribute.
+    - `"arguments"`: an array of attribute arguments.
 - `"loggedTypes"`: an array describing all instances of [`log`](../fuel-vm/instruction-set.md#log-log-event) or [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
   - `"logId"`: a string containing the 64bit hash based decimal ID calculated from the first 8 bytes of the `sha256` of a string that represents the type logged as defined in [Hash Based Ids](./hash-based-ids.md). The [`log`](../fuel-vm/instruction-set.md#log-log-event) and [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
-  - `"loggedType"`: the _type concrete declaration_ hash based ID of the value being logged.
+  - `"concreteTypeId"`: the _type concrete declaration_ hash based ID of the value being logged.
 - `"messagesTypes"`: an array describing all instances of [`smo`](../fuel-vm/instruction-set.md#smo-send-message-to-output) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
   - `"message_id"`: a unique string ID.
-  - `"messageDataType"`: the _type concrete declaration_ hash based ID of the message data being sent.
+  - `"concreteTypeId"`: the _type concrete declaration_ hash based ID of the message data being sent.
 - `"configurables"`: an array describing all `configurable` variables used in the contract. Each `configurable` variable is represented as a JSON object that contains the following properties:
   - `"name"`: the name of the `configurable` variable.
-  - `"configurableType"`: the _type concrete declaration_ hash based ID of the type of the `configurable` variable.
+  - `"concreteTypeId"`: the _type concrete declaration_ hash based ID of the type of the `configurable` variable.
   - `"offset"`: the specific offset within the contract's bytecode, in bytes, to the data section entry for the `configurable` variable.
 
 > **Note**: This JSON should be both human-readable and parsable by the tooling around the FuelVM and the Sway programming language. There is a detailed specification for the binary encoding backing this readable descriptor. The [Function Selector Encoding](./fn-selector-encoding.md) section specifies the encoding for the function being selected to be executed and each of the argument types.
@@ -401,7 +404,7 @@ its JSON representation would look like:
       "components": [
         {
           "name": "__tuple_element",
-          "typeId": "2",
+          "typeId": 2,
         },
         {
           "name": "__tuple_element",
@@ -447,7 +450,7 @@ its JSON representation would look like:
         },
         {
           "name": "bam",
-          "typeId": "3",
+          "typeId": 3,
         }
       ]
     },
@@ -534,11 +537,11 @@ its JSON representation would look like:
       "components": [
         {
           "name": "Foo",
-          "type": 2,
+          "typeId": 2,
         },
         {
           "name": "Bar",
-          "type": 3,
+          "typeId": 3,
         }
       ],
       "typeParameters": [2, 3]
@@ -561,13 +564,13 @@ its JSON representation would look like:
       "components": [
         {
           "name": "bam",
-          "type": 1,
+          "typeId": 1,
           "typeArguments": [
             {
-              "typeId": "4",
+              "typeId": 4,
             },
             {
-              "typeId": "4",
+              "typeId": 4,
             }
           ]
         }
@@ -653,7 +656,7 @@ its JSON representation would look like:
       "components": [
         {
           "name": "x",
-          "typeId": "2",
+          "typeId": 2,
           "typeArguments": null
         }
       ],
@@ -674,11 +677,11 @@ its JSON representation would look like:
   "loggedTypes": [
     {
       "logId": "12896678128313068780",
-      "loggedType": "b2fa346d9ca66ceca61951a27dba2977b2a82b8aa8600670604f286a1393dffe"
+      "concreteTypeId": "b2fa346d9ca66ceca61951a27dba2977b2a82b8aa8600670604f286a1393dffe"
     },
     {
       "logId": "16383228984366451899",
-      "loggedType": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389"
+      "concreteTypeId": "eca2a040ce95fc19b7cd5f75bac530d052484d0b1a49267a2eb07a7a1b00c389"
     }
   ]
 }

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -41,7 +41,7 @@ The ABI of a contract is represented as a JSON object containing the following p
   - `"concreteTypeId"`: a unique string hash based ID. Generated as specified in [Hash Based Ids](./hash-based-ids.md).
   - `"metadataTypeId"`: the the _type metadata declaration_ ID of this type, if the type metadata has components or is generic, otherwise non existent.
   - `"typeArguments"`: an array of _type concrete declarations_ hash based IDs of the type parameters of the type, if the type is generic, otherwise non existent.
-- `"typesMetadata"`: an array describing all the _type metadata declarations_ used (or transitively used) in the ABI. Each _type metadata declaration_ is a JSON object that contains the following properties:
+- `"metadataTypes"`: an array describing all the _type metadata declarations_ used (or transitively used) in the ABI. Each _type metadata declaration_ is a JSON object that contains the following properties:
   - `"type"`: a string representation of the _type metadata declaration_. The section [JSON ABI Format for Each Possible Metadata Type Declaration](#json-abi-format-for-each-possible-metadata-type-declaration) specifies the format for each possible type.
   - `"metadataTypeId"`: a unique integer ID.
   - `"components"`: an array of the components of a given type, if any, otherwise non existent. Each component is a _type application_ represented as a JSON object that contains the following properties:
@@ -117,7 +117,7 @@ the JSON representation of this ABI looks like:
       "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
     }
   ],
-  "typesMetadata": [],
+  "metadataTypes": [],
   "functions": [
     {
       "inputs": [
@@ -391,7 +391,7 @@ its JSON representation would look like:
       "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
     }
   ],
-  "typesMetadata": [
+  "metadataTypes": [
     {
       "metadataTypeId": 1,
       "type": "(_, _, _)",
@@ -524,7 +524,7 @@ its JSON representation would look like:
       "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
     }
   ],
-  "typesMetadata": [
+  "metadataTypes": [
     {
       "metadataTypeId": 1,
       "type": "enum MyEnum",
@@ -643,7 +643,7 @@ its JSON representation would look like:
       "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
     }
   ],
-  "typesMetadata": [
+  "metadataTypes": [
     {
       "metadataTypeId": 1,
       "type": "struct MyStruct",

--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -39,18 +39,18 @@ The ABI of a contract is represented as a JSON object containing the following p
 - `"concreteTypes"`: an array describing all the _type concrete declarations_ used (or transitively used) in the ABI. Each _type concrete declaration_ is a JSON object that contains the following properties:
   - `"type"`: a string representing the type, the `sha256` of this string generates the `concreteTypeId`.
   - `"concreteTypeId"`: a unique string hash based ID. Generated as specified in [Hash Based Ids](./hash-based-ids.md).
-  - `"metadataTypeId"`: the the _type metadata declaration_ ID of this type, if the type metadata has components or is generic, otherwise non existent.
-  - `"typeArguments"`: an array of _type concrete declarations_ hash based IDs of the type parameters of the type, if the type is generic, otherwise non existent.
+  - `"metadataTypeId"`: the _type metadata declaration_ ID of this type, if the type metadata has components or is generic, otherwise nonexistent.
+  - `"typeArguments"`: an array of _type concrete declarations_ hash based IDs of the type parameters of the type, if the type is generic, otherwise nonexistent.
 - `"metadataTypes"`: an array describing all the _type metadata declarations_ used (or transitively used) in the ABI. Each _type metadata declaration_ is a JSON object that contains the following properties:
   - `"type"`: a string representation of the _type metadata declaration_. The section [JSON ABI Format for Each Possible Metadata Type Declaration](#json-abi-format-for-each-possible-metadata-type-declaration) specifies the format for each possible type.
   - `"metadataTypeId"`: a unique integer ID.
-  - `"components"`: an array of the components of a given type, if any, otherwise non existent. Each component is a _type application_ represented as a JSON object that contains the following properties:
+  - `"components"`: an array of the components of a given type, if any, otherwise nonexistent. Each component is a _type application_ represented as a JSON object that contains the following properties:
     - `"name"`: the name of the component.
     - `"typeId"`: the _type metadata declaration_ ID (number) or _type concrete declaration_ hash based ID (string) of the type of the component.
-    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the component, if the type is generic, otherwise non existent. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
+    - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the component, if the type is generic, otherwise nonexistent. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
       - `"typeId"`: the _type metadata declaration_ ID (number) or _type concrete declaration_ hash based ID (string) of the type of the component.
-      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, otherwise non existent. The format of the elements of this array recursively follows the rules described in this section.
-  - `"typeParameters"`: an array of _type metadata declaration_ ID of the _type parameters_ of the type, if the type is generic, otherwise non existent. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).
+      - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, otherwise nonexistent. The format of the elements of this array recursively follows the rules described in this section.
+  - `"typeParameters"`: an array of _type metadata declaration_ ID of the _type parameters_ of the type, if the type is generic, otherwise nonexistent. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).
 - `"functions`": an array describing all the functions in the ABI. Each function is a JSON object that contains the following properties:
   - `"name"`: the name of the function
   - `"inputs"`: an array of objects that represents the inputs to the function (i.e. its parameters). Each input is a _type application_ represented as a JSON object that contains the following properties:


### PR DESCRIPTION
https://github.com/FuelLabs/sway/issues/5151
https://github.com/FuelLabs/sway/issues/5952
https://github.com/FuelLabs/sway/issues/5954

[Rendered file](https://github.com/FuelLabs/fuel-specs/blob/882a860a4aa11ba8c6f91085a0ab4d483c6ce3fb/src/abi/json-abi-format.md)

With the changes proposed in this PR, functions,loggedTypes, messagesTypes and configurables will only rely on hash based ids of concrete types.

This change is required because types on the types arrays can be abstract types, so the hash based ids could not include the generic parameters of the concrete types used.

For instance a method with two args, `Option<u64>` and `Option<u32>`, would generate two distinct hash based ids based on `sha256("enum std::option::Option<u64>")` and `sha256("enum std::option::Option<u32>")`, but there was a single type for Option.

With the proposed changes we can now have multiple hash based ids for generic types, while still having access to the same generated types as the new `concreteTypes` map easily to the `typesMetadata` (old `types`).

### Before requesting review
- [x] I have reviewed the code myself

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Typescript SDK](https://github.com/FuelLabs/fuels-ts/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
