### PR TITLE
change ed19 verify operator, to comply with ed spec

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2286,7 +2286,7 @@ Panic if:
 
 Verification are specified [here](../protocol/cryptographic-primitives.md#eddsa-public-key-cryptography).
 
-If register `$rD` is provided with `0` or not provided. It will be set to default `32`.
+If register `$rD` is provided with `0`. It will be set to default `32`.
 
 If there is an error in verification, `$err` is set to `1`, otherwise `$err` is cleared.
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2275,7 +2275,7 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 | Operation   | ```ed19verify(MEM[$rA, 32], MEM[$rB, 64], MEM[$rC, $rD]);```                                                                |
 | Syntax      | `ed19 $rA, $rB, $rC, $rD`                                                                                                   |
 | Encoding    | `0x00 rA rB rC rD`                                                                                                          |
-| Notes       | Takes message instead of hash. **For backwards compatibility reasons, if `$rD == 0`, it will be set treated as `32`.**      |
+| Notes       | Takes message instead of hash. **For backwards compatibility reasons, if `$rD == 0`, it will be treated as `32`.**          |
 
 Panic if:
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2269,21 +2269,24 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 
 ### `ED19`: EdDSA curve25519 verification
 
-|             |                                                                                                                                                     |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| Description | Verification recovered from 32-byte public key starting at `$rA` and 64-byte signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
-| Operation   | ```ed19verify(MEM[$rA, 32], MEM[$rB, 64], MEM[$rC, 32]);```                                                                                         |
-| Syntax      | `ed19 $rA, $rB, $rC`                                                                                                                                |
-| Encoding    | `0x00 rA rB rC -`                                                                                                                                   |
-| Notes       |                                                                                                                                                     |
+|             |                                                                                                                                                                 |
+|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Description | Verification recovered from 32-byte public key starting at `$rA`, 64-byte signature starting at `$rB`, message starting byte `$rC` and message byte size `$rD`. |
+| Operation   | ```ed19verify(MEM[$rA, 32], MEM[$rB, 64], MEM[$rC, $rD]);```                                                                                                    |
+| Syntax      | `ed19 $rA, $rB, $rC, $rD`                                                                                                                                       |
+| Encoding    | `0x00 rA rB rC rD`                                                                                                                                              |
+| Notes       |                                                                                                                                                                 |
 
 Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
 - `$rB + 64` overflows or `> VM_MAX_RAM`
-- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rC + $rD` overflows or `> VM_MAX_RAM`
+- `$rD > 1024`.
 
 Verification are specified [here](../protocol/cryptographic-primitives.md#eddsa-public-key-cryptography).
+
+If register `$rD` is provided with `0` or not provided. It will be set to default `32`.
 
 If there is an error in verification, `$err` is set to `1`, otherwise `$err` is cleared.
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2285,8 +2285,6 @@ Panic if:
 
 Verification are specified [here](../protocol/cryptographic-primitives.md#eddsa-public-key-cryptography).
 
-
-
 If there is an error in verification, `$err` is set to `1`, otherwise `$err` is cleared.
 
 ### `K256`: keccak-256

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2229,7 +2229,7 @@ All these instructions advance the program counter `$pc` by `4` after performing
 | Operation   | ```MEM[$rA, 64] = ecrecover_k1(MEM[$rB, 64], MEM[$rC, 32]);```                                                              |
 | Syntax      | `eck1 $rA, $rB, $rC`                                                                                                        |
 | Encoding    | `0x00 rA rB rC -`                                                                                                           |
-| Notes       |                                                                                                                             |
+| Notes       | Takes message hash as an input. You can use `S256` to hash the message if needed.                                           |
 
 Panic if:
 
@@ -2252,7 +2252,7 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 | Operation   | ```MEM[$rA, 64] = ecrecover_r1(MEM[$rB, 64], MEM[$rC, 32]);```                                                              |
 | Syntax      | `ecr1 $rA, $rB, $rC`                                                                                                        |
 | Encoding    | `0x00 rA rB rC -`                                                                                                           |
-| Notes       |                                                                                                                             |
+| Notes       | Takes message hash as an input. You can use `S256` to hash the message if needed.                                           |
 
 Panic if:
 
@@ -2269,24 +2269,23 @@ To get the address from the public key, hash the public key with [SHA-2-256](../
 
 ### `ED19`: EdDSA curve25519 verification
 
-|             |                                                                                                                                                                 |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Description | Verification recovered from 32-byte public key starting at `$rA`, 64-byte signature starting at `$rB`, message starting byte `$rC` and message byte size `$rD`. |
-| Operation   | ```ed19verify(MEM[$rA, 32], MEM[$rB, 64], MEM[$rC, $rD]);```                                                                                                    |
-| Syntax      | `ed19 $rA, $rB, $rC, $rD`                                                                                                                                       |
-| Encoding    | `0x00 rA rB rC rD`                                                                                                                                              |
-| Notes       |                                                                                                                                                                 |
+|             |                                                                                                                             |
+|-------------|-----------------------------------------------------------------------------------------------------------------------------|
+| Description | Verification 64-byte signature at `$rB` with 32-byte public key at `$rA` for a message starting at `$rC` with length `$rD`. |
+| Operation   | ```ed19verify(MEM[$rA, 32], MEM[$rB, 64], MEM[$rC, $rD]);```                                                                |
+| Syntax      | `ed19 $rA, $rB, $rC, $rD`                                                                                                   |
+| Encoding    | `0x00 rA rB rC rD`                                                                                                          |
+| Notes       | Takes message instead of hash. **For backwards compatibility reasons, if `$rD == 0`, it will be set treated as `32`.**      |
 
 Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
 - `$rB + 64` overflows or `> VM_MAX_RAM`
 - `$rC + $rD` overflows or `> VM_MAX_RAM`
-- `$rD > 1024`.
 
 Verification are specified [here](../protocol/cryptographic-primitives.md#eddsa-public-key-cryptography).
 
-If register `$rD` is provided with `0`. It will be set to default `32`.
+
 
 If there is an error in verification, `$err` is set to `1`, otherwise `$err` is cleared.
 


### PR DESCRIPTION
When using EdDSA (Ed25519) to verify a signature, the payload is not limited by 32 bytes.

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] [Connectors](https://github.com/FuelLabs/fuel-connectors/)