### PR TITLE
Fix `cfei -> cfe` typo in `instruction-set.md`

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -1309,7 +1309,7 @@ Panic if:
 |-------------|----------------------------------------|
 | Description | Extend the current call frame's stack. |
 | Operation   | ```$sp = $sp + $rA```                  |
-| Syntax      | `cfei $rA`                             |
+| Syntax      | `cfe $rA`                             |
 | Encoding    | `0x00 rA - - -`                        |
 | Notes       | Does not initialize memory.            |
 


### PR DESCRIPTION
Found while reviewing https://github.com/FuelLabs/fuels-rs/pull/1472.

### Before requesting review
- [x] I have reviewed the code myself