### PR TITLE
Skip panic reason in the canonical form

### DIFF
--- a/src/abi/receipts.md
+++ b/src/abi/receipts.md
@@ -39,7 +39,8 @@ _Important note:_ For the JSON representation of receipts, we represent 64-bit u
 
 - `type`: `Panic`.
 - `id`: Hexadecimal string representation of the 256-bit (32-byte) contract ID of the current context if in an internal context. `null` otherwise.
-- `reason`: Decimal string representation of an 8-bit unsigned integer; panic reason.
+- `reason`: Optional decimal string representation of an 8-bit unsigned integer; panic reason.
+  Not included in canonical receipt form.
 - `pc`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$pc`.
 - `is`: Hexadecimal string representation of a 64-bit unsigned integer; value of register `$is`.
 - `contractId`: Optional hexadecimal string representation of the 256-bit (32-byte) contract ID if applicable. `null` otherwise.


### PR DESCRIPTION
The main reason for removing it from canonical serialization is to avoid affecting the block ID for different panic reasons. The primary goal is just to know that some operation was done incorrectly; what exactly failed is less important. It reduces the chance of getting different blocks within one panic.

Related VM change: https://github.com/FuelLabs/fuel-vm/pull/826

### Before requesting review
- [x] I have reviewed the code myself
