### PR TITLE
Remove erroneous "Notes" from `SUB` and `SUBI` instructions

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -669,7 +669,7 @@ Panic if:
 | Operation   | ```$rA = $rB - $rC;```                           |
 | Syntax      | `sub $rA, $rB, $rC`                              |
 | Encoding    | `0x00 rA rB rC -`                                |
-| Notes       | `$of` is assigned the overflow of the operation. |
+| Notes       |                                                  |
 
 Panic if:
 
@@ -687,7 +687,7 @@ Panic if:
 | Operation   | ```$rA = $rB - imm;```                           |
 | Syntax      | `subi $rA, $rB, imm`                             |
 | Encoding    | `0x00 rA rB i i`                                 |
-| Notes       | `$of` is assigned the overflow of the operation. |
+| Notes       |                                                  |
 
 Panic if:
 


### PR DESCRIPTION
### Description

This PR fixes the documentation of the `SUB` and `SUBI` instructions and makes it follow the same pattern as the `ADD` and `ADDI` instructions.

The documentation was wrongly using the term "overflow" in the "Notes" of those two instructions, instead of "underflow" (as used in the longer explanation below the instruction).

The PR simply removes the erroneous description from the "Notes" and leaves them empty, as in `ADD` and `ADDI`.

### Before requesting review
- [x] I have reviewed the code myself