### PR TITLE
Add missing type argument name from ABI spec

### DIFF
--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -48,6 +48,7 @@ The ABI of a contract is represented as a JSON object containing the following p
     - `"name"`: the name of the component.
     - `"typeId"`: the _type metadata declaration_ ID (number) or _type concrete declaration_ hash based ID (string) of the type of the component.
     - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the component, if the type is generic, otherwise nonexistent. Each _type argument_ is a _type application_ represented as a JSON object that contains the following properties:
+      - `"name"`: the name of the _type argument_.
       - `"typeId"`: the _type metadata declaration_ ID (number) or _type concrete declaration_ hash based ID (string) of the type of the component.
       - `"typeArguments"`: an array of the _type arguments_ used when applying the type of the _type argument_, if the type is generic, otherwise nonexistent. The format of the elements of this array recursively follows the rules described in this section.
   - `"typeParameters"`: an array of _type metadata declaration_ ID of the _type parameters_ of the type, if the type is generic, otherwise nonexistent. Each _type parameter_ is a type declaration and is represented as described in [Generic Type Parameter](#generic-type-parameter).


### PR DESCRIPTION
In the ABI spec, a `typeArgument` is missing the `name` property, as shown [here](https://github.com/FuelLabs/sway/blob/0ccf47bbf991617af4e7f238f704a8ab5de5d184/forc-plugins/forc-client/test/data/deployed_script/deployed_script-loader-abi.json#L168-L173).

### Before requesting review
- [x] I have reviewed the code myself

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [x] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
