### PR TITLE
Jump-and-link instruction

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -61,6 +61,7 @@
   - [`JNZF`: Jump if not zero relative forwards](#jnzf-jump-if-not-zero-relative-forwards)
   - [`JNEB`: Jump if not equal relative backwards](#jneb-jump-if-not-equal-relative-backwards)
   - [`JNEF`: Jump if not equal relative forwards](#jnef-jump-if-not-equal-relative-forwards)
+  - [`JAL`: Jump and link](#jal-jump-and-link)
   - [`RET`: Return from context](#ret-return-from-context)
 - [Memory Instructions](#memory-instructions)
   - [`ALOC`: Allocate memory](#aloc-allocate-memory)
@@ -1296,6 +1297,21 @@ Panic if:
 Panic if:
 
 - `$pc + ($rC + imm + 1) * 4 > VM_MAX_RAM - 1`
+
+### `JAL`: Jump and link
+
+|             |                                                                                           |
+|-------------|-------------------------------------------------------------------------------------------|
+| Description | Set `$rA` to address of the next instruction. Jump to instruction at address `$rB + imm`. |
+| Operation   | `if $rA is not $zero { $rA = $pc + 4 }` <br> `$pc = $rB + imm + 4`                        |
+| Syntax      | `jal $rA $rB imm`                                                                         |
+| Encoding    | `0x00 rA rB i i`                                                                          |
+| Notes       | If `$rA` is `$zero`, the return address discarded.                                        |
+
+Panic if:
+
+- `$rA` is a reserved register other than `$zero`
+- `$rB + imm * 4 >= VM_MAX_RAM`
 
 ### `RET`: Return from context
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -1300,13 +1300,13 @@ Panic if:
 
 ### `JAL`: Jump and link
 
-|             |                                                                                           |
-|-------------|-------------------------------------------------------------------------------------------|
-| Description | Set `$rA` to address of the next instruction. Jump to instruction at address `$rB + imm`. |
-| Operation   | `if $rA is not $zero { $rA = $pc + 4 }` <br> `$pc = $rB + imm + 4`                        |
-| Syntax      | `jal $rA $rB imm`                                                                         |
-| Encoding    | `0x00 rA rB i i`                                                                          |
-| Notes       | If `$rA` is `$zero`, the return address discarded.                                        |
+|             |                                                                                               |
+|-------------|-----------------------------------------------------------------------------------------------|
+| Description | Set `$rA` to address of the next instruction. Jump to instruction at address `$rB + imm * 4`. |
+| Operation   | `if $rA is not $zero { $rA = $pc + 4 }` <br> `$pc = $rB + imm * 4`                            |
+| Syntax      | `jal $rA $rB imm`                                                                             |
+| Encoding    | `0x00 rA rB i i`                                                                              |
+| Notes       | If `$rA` is `$zero`, the return address discarded.                                            |
 
 Panic if:
 


### PR DESCRIPTION
Closes #627. VM issue: https://github.com/FuelLabs/fuel-vm/issues/857. VM PR: https://github.com/FuelLabs/fuel-vm/pull/925.

The design is quite similar of the RISC-V of the same name. `JAL $ra $rb imm` stores the address of the next instruction to `$ra`, so that register can be used as a return address from the subroutine. If `ra` is `$zero`, the value is discarded instead, so this can be used as a jump without having to trash a register. After storing the return address, it jumps to instruction at memory address `$rb + imm * 4`.

The main purpose of this instruction is efficient subroutine-calling and returning. `JAL $ret_addr $subroutine_addr 0` is used to perform the call, and `JAL $zero $ret_addr 0` returns from it. For nexted function calls, the callee is responsible for storing the `$ret_addr`.

The following snippet shows a minimal program using the functionality:

```rust
// main function
jal $ret_addr $pc 2 // call subroutine
ret $zero // end program

// subroutine
/* subroutine body comes here */
jal $zero $ret_addr 0 // Return from the subroutine
```

### Fibonacci example

To show off how compact code this makes, I wrote a small fibonacci function using it. The function here uses the following register-based ABI:
* Function argument and return value `$fnarg` in `0x10` 
* Function return address `$return_addr` in `0x11` 

Also the code uses the following locals: `$local1: 0x12, $local2: 0x13, $local3: 0x14` (named for `pshl/popl`) 

```rust
// Set argument
movi $fnarg 10 // <- this computes fibo(10), i.e. 10th fibonacci number, 55

// Main function
jal $return_addr $pc 3 // <- offset to the subroutine
log $fnarg $zero $zero $zero
ret $one

// Fibonacci subroutine
// fibo(0) = 0, fibo(1) = 1, fibo(n) = fibo(n-1) + fibo(n-2)
pshl 0b11110 // Save return_address and local{1,2,3}
// Compute fn pointer to the current function and place it in local3
subi $local3 $pc 4 // <- subtract 4 to get prev instruction start
// If n < 2 no computation needed
movi $local1 2
lt $local1 $fnarg $local1
jnzf $local1 $zero 8 // Skip over computation
// Else call self with n - 1 and n - 2 and sum those
subi $local2 $fnarg 2         // Save n - 2 to local2
subi $fnarg $fnarg 1          // n -= 1
jal $return_addr $local3 0    // Call self
move $local1 $fnarg           // Copy result to local1
move $fnarg $local2           // Restore n - 2 from local2
jal $return_addr $local3 0    // Call self
move $local2 $fnarg           // Copy result to local2
add $fnarg $local1 $local2 // result = local1 + local2
// Computation ends here this is where jnzf jumps to
popl 0b11110 // Restore return_address and local{1,2,3}
jal $zero $return_addr 0 // Return from subroutine
```

### Before requesting review
- [x] I have reviewed the changes myself
