### PR TITLE
Changed `message_id` to `messageId` in the `messageTypes`

### DIFF
--- a/src/abi/json-abi-format.md
+++ b/src/abi/json-abi-format.md
@@ -65,7 +65,7 @@ The ABI of a contract is represented as a JSON object containing the following p
   - `"logId"`: a string containing the 64bit hash based decimal ID calculated from the first 8 bytes of the `sha256` of a string that represents the type logged as defined in [Hash Based Ids](./hash-based-ids.md). The [`log`](../fuel-vm/instruction-set.md#log-log-event) and [`logd`](../fuel-vm/instruction-set.md#logd-log-data-event) instructions must set their `$rB` register to that ID.
   - `"concreteTypeId"`: the _type concrete declaration_ hash based ID of the value being logged.
 - `"messagesTypes"`: an array describing all instances of [`smo`](../fuel-vm/instruction-set.md#smo-send-message-to-output) in the contract's bytecode. Each instance is a JSON object that contains the following properties:
-  - `"message_id"`: a unique string ID.
+  - `"messageId"`: a unique string ID.
   - `"concreteTypeId"`: the _type concrete declaration_ hash based ID of the message data being sent.
 - `"configurables"`: an array describing all `configurable` variables used in the contract. Each `configurable` variable is represented as a JSON object that contains the following properties:
   - `"name"`: the name of the `configurable` variable.


### PR DESCRIPTION
Closes:
- #603 

There is a typo in the specification for `messageTypes`; it should be `messageId` and not `message_id`. All ABI's currently are generated with this schema.

### Before requesting review
- [X] I have reviewed the code myself

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
