### PR TITLE
Add GM flag to fetch the current gas price

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2622,6 +2622,7 @@ Read metadata from memory. A convenience instruction to avoid manually extractin
 | `GM_GET_CHAIN_ID`            | `0x00004` | Get the value of `CHAIN_ID`      |
 | `GM_TX_START`                | `0x00005` | Transaction start memory address |
 | `GM_BASE_ASSET_ID`           | `0x00006` | Base asset ID                    |
+| `GM_GET_GAS_PRICE`           | `0x00007` | Get the gas price of the block.  |
 
 If `imm == GM_IS_CALLER_EXTERNAL`:
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2648,6 +2648,14 @@ Panic if:
 
 Set `$rA` to the index of the currently-verifying predicate.
 
+If `imm == GM_GET_GAS_PRICE`:
+
+Panic if:
+
+- in a predicate context
+
+Set `$rA` to the gas price of the block.
+
 ### `GTF`: Get transaction fields
 
 |             |                                         |


### PR DESCRIPTION
Introduce a new GM flag to retrieve the gas price of the block, enabling the functionality for gas price access inside of scripts or contracts.

closes #631 