### PR TITLE
Add SUB operation to NIOP

### DIFF
--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -563,10 +563,11 @@ Then the actual operation that's performed:
 `op` | Name | Description
 -----|-------|---------------------------
 0    | `add` | Add (`a = b + c`)
-1    | `mul` | Multiply (`a = b * c`)
-2    | `exp` | Exponentiate (`a = b ** c`)
-3    | `sll` | Bit shift left (logical) (`a = b << c`)
-4    | `xnor`| Bitwise xnor (`a = b ^ (!c)`).
+1    | `sub` | Subtract (`a = b - c`)
+2    | `mul` | Multiply (`a = b * c`)
+3    | `exp` | Exponentiate (`a = b ** c`)
+4    | `sll` | Bit shift left (logical) (`a = b << c`)
+5    | `xnor`| Bitwise xnor (`a = b ^ (!c)`).
 other| -     | Reserved and must not be used
 
 And operation width:
@@ -583,6 +584,7 @@ then perform the operation with overflow checking on that size. The
 result always fits within the bit width of the operation.
 
 Operations set `$of` and `$err` similarly to their 64-bit counterparts.
+For subtraction specifically, this means that an overflowing operation sets `$of` to all ones (`2**64-1`).
 `XNOR` has no counterpart, and it always clears both `$of` and `$err`.
 
 Panic if:


### PR DESCRIPTION
When implemention `niop`, I discovered that the subtraction via `sub` instruction doesn't work for narrower integer types, as the result will not be properly truncated if the operation overflows. This PR adds subtraction mode, corresponding the the commit https://github.com/FuelLabs/fuel-vm/pull/922/commits/99433f9889112de59d231a44ad954c9a534e376e in the fuel-vm branch. SInce the `niop` isn't implemented yet, we can freely change the operation table to keep it more consistent.


### Before requesting review
- [x] I have reviewed the code myself