### PR TITLE
Dynamic storage opcodes: base instructions

### DIFF
--- a/spell-check-custom-words.txt
+++ b/spell-check-custom-words.txt
@@ -233,6 +233,7 @@ SMTs
 subtrees
 subtree
 prepended
+preload
 preloaded
 unhashed
 preimage

--- a/spell-check-custom-words.txt
+++ b/spell-check-custom-words.txt
@@ -284,4 +284,4 @@ imm
 rA
 rB
 rC
-spcp
+rD

--- a/spell-check-custom-words.txt
+++ b/spell-check-custom-words.txt
@@ -233,6 +233,7 @@ SMTs
 subtrees
 subtree
 prepended
+preloaded
 unhashed
 preimage
 FIPS

--- a/spell-check-custom-words.txt
+++ b/spell-check-custom-words.txt
@@ -280,3 +280,8 @@ eips
 ethereum
 xnor
 XNOR
+imm
+rA
+rB
+rC
+spcp

--- a/src/fuel-vm/index.md
+++ b/src/fuel-vm/index.md
@@ -170,9 +170,9 @@ A call frame consists of the following, word-aligned:
 |       |               |            | **Unwritable area ends.**                                                     |
 | *     |               |            | Call frame's stack.                                                           |
 
-### Storage preload staging area
+### Storage cache
 
-The storage preload instruction `SPLD` loads contents of a storage slot into a staging area. This is a special memory region only readable with `SPCP` instruction. The staging area is cleared every time a call or return occurs.
+All storage values are cached on first access. Subsequent accesses to the same slot are much cheaper than the initial one. This principle holds for both reads and writes, since the first write needs to also know slot's contents to charge for possibly increased contract state size. The cache persists across contract call boundary.
 
 ## Access rights
 

--- a/src/fuel-vm/index.md
+++ b/src/fuel-vm/index.md
@@ -170,6 +170,10 @@ A call frame consists of the following, word-aligned:
 |       |               |            | **Unwritable area ends.**                                                     |
 | *     |               |            | Call frame's stack.                                                           |
 
+### Storage preload staging area
+
+The storage preload instruction `PSLD` loads contents of a storage slot into a staging area. This is a special memory region only readable with `SPCP` instruction. The staging area is cleared every time a call or return occurs.
+
 ## Access rights
 
 Only memory that has been allocated is accessible.

--- a/src/fuel-vm/index.md
+++ b/src/fuel-vm/index.md
@@ -172,7 +172,7 @@ A call frame consists of the following, word-aligned:
 
 ### Storage preload staging area
 
-The storage preload instruction `PSLD` loads contents of a storage slot into a staging area. This is a special memory region only readable with `SPCP` instruction. The staging area is cleared every time a call or return occurs.
+The storage preload instruction `SPLD` loads contents of a storage slot into a staging area. This is a special memory region only readable with `SPCP` instruction. The staging area is cleared every time a call or return occurs.
 
 ## Access rights
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -107,7 +107,7 @@
   - [`TR`: Transfer coins to contract](#tr-transfer-coins-to-contract)
   - [`TRO`: Transfer coins to output](#tro-transfer-coins-to-output)
   - [Contract State Instructions](#contract-state-instructions)
-    - [`SCWQ`: DEPRECATED State clear sequential 32 bytes slots](#scwq-deprecated-state-clear-sequential-slots)
+    - [`SCWQ`: DEPRECATED State clear sequential 32 bytes slots](#scwq-deprecated-state-clear-sequential-32-bytes-slots)
     - [`SRW`: State read word](#srw-state-read-word)
     - [`SRWQ`: DEPRECATED State read sequential 32 byte slots](#srwq-deprecated-state-read-sequential-32-byte-slots)
     - [`SWW`: State write word](#sww-state-write-word)
@@ -2466,7 +2466,7 @@ Panic if:
 - `imm > MAX_STORAGE_SLOT_SIZE`
 - `$fp == 0` (in the script context)
 
-### `SUPD`: Update storage slot (partial write)
+### `SUPD`: State update slot (partial write)
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2428,7 +2428,7 @@ Panic if:
 - `$rC + imm` overflows or `> len(STATE[MEM[$rC, 32]])`
 - `$fp == 0` (in the script context)
 
-Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
+Register `$err` will be set to `1` if the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
 
 ### `SWRD`: Write storage slot
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2407,7 +2407,7 @@ Panic if:
 - `$rC + $rD` overflows or `> len(STATE[MEM[$rB, 32]])`
 - `$fp == 0` (in the script context)
 
-Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
+Register `$err` will be set to `1` if the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
 
 ### `SRDI`: Read storage slot immediate
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -115,7 +115,7 @@
     - [`SCLR`: State clear sequential slots](#sclr-state-clear-sequential-slots)
     - [`SRDD`: State read slot](#srdd-state-read-slot)
     - [`SRDI`: State read slot immediate](#srdi-state-read-slot-immediate)
-    - [`SWRD`: Write storage slot](#swrd-write-storage-slot)
+    - [`SWRD`: State write slot](#swrd-state-write-slot)
     - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
     - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
     - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -120,7 +120,6 @@
     - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
     - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
     - [`SPLD`: Storage preload](#spld-storage-preload)
-    - [`SPCP`: Copy from preloaded storage slot](#spcp-copy-from-preloaded-storage-slot)
 - [Blob Instructions](#blob-instructions)
   - [`BSIZ`: Blob size](#bsiz-blob-size)
   - [`BLDD`: Load data from a blob](#bldd-load-data-from-a-blob)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2430,7 +2430,7 @@ Panic if:
 
 Register `$err` will be set to `1` if the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
 
-### `SWRD`: Write storage slot
+### `SWRD`: State write slot
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2404,6 +2404,7 @@ Panic if:
 
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA + $rD` overflows or `> VM_MAX_RAM`
+- The memory range `MEM[$rA, $rD]` does not pass [ownership check](./index.md#ownership)
 - `$rC + $rD` overflows or `> len(STATE[MEM[$rB, 32]])`
 - `$fp == 0` (in the script context)
 
@@ -2424,6 +2425,7 @@ Panic if:
 
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA + imm` overflows or `> VM_MAX_RAM`
+- The memory range `MEM[$rA, imm]` does not pass [ownership check](./index.md#ownership)
 - `$rC + imm` overflows or `> len(STATE[MEM[$rC, 32]])`
 - `$fp == 0` (in the script context)
 
@@ -2540,6 +2542,7 @@ If the slot doesn't exist, sets `$rA = 0` and `$err = 1`, leaving the staging ar
 Panic if:
 
 - `$rA + $rC + imm` overflows or `> VM_MAX_RAM`
+- The memory range `MEM[$rA, $rC + imm]` does not pass [ownership check](./index.md#ownership)
 - `$rB + $rC + imm` overflows or `> len(STAGING)`
 - `$fp == 0` (in the script context)
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2309,7 +2309,7 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics)
 - `$rC + 32` overflows or `> VM_MAX_RAM`
 - `$fp == 0` (in the script context)
-- `len(STATE[MEM[$rC, 32]]) < imm * 8 + 8` (the storage slot doesn't have enough data)
+- `len(STATE[MEM[$rC, 32]]) < imm * 8 + 8` when the slot is set (the storage slot doesn't have enough data)
 
 Register `$rB` will be set to `false` if the requested slot is unset (default) and `true` if it's set.
 
@@ -2404,7 +2404,7 @@ Panic if:
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA + $rD` overflows or `> VM_MAX_RAM`
 - The memory range `MEM[$rA, $rD]` does not pass [ownership check](./index.md#ownership)
-- `$rC + $rD` overflows or `> len(STATE[MEM[$rB, 32]])`
+- `$rC + $rD` overflows or `> len(STATE[MEM[$rB, 32]])` when the slot is set
 - `$fp == 0` (in the script context)
 
 Register `$err` will be set to `1` if the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
@@ -2425,7 +2425,7 @@ Panic if:
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA + imm` overflows or `> VM_MAX_RAM`
 - The memory range `MEM[$rA, imm]` does not pass [ownership check](./index.md#ownership)
-- `$rC + imm` overflows or `> len(STATE[MEM[$B, 32]])`
+- `$rC + imm` overflows or `> len(STATE[MEM[$B, 32]])` when the slot is set
 - `$fp == 0` (in the script context)
 
 Register `$err` will be set to `1` if the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2425,7 +2425,7 @@ Panic if:
 - `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA + imm` overflows or `> VM_MAX_RAM`
 - The memory range `MEM[$rA, imm]` does not pass [ownership check](./index.md#ownership)
-- `$rC + imm` overflows or `> len(STATE[MEM[$rC, 32]])`
+- `$rC + imm` overflows or `> len(STATE[MEM[$B, 32]])`
 - `$fp == 0` (in the script context)
 
 Register `$err` will be set to `1` if the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -119,7 +119,8 @@
     - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
     - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
     - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
-    - [`SPRL`: Storage preload](#sprl-storage-preload)
+    - [`SPLD`: Storage preload](#spld-storage-preload)
+    - [`SPCP`: Copy from preloaded storage slot](#spcp-copy-from-preloaded-storage-slot)
 - [Blob Instructions](#blob-instructions)
   - [`BSIZ`: Blob size](#bsiz-blob-size)
   - [`BLDD`: Load data from a blob](#bldd-load-data-from-a-blob)
@@ -2374,13 +2375,13 @@ Panic if:
 
 Register `$rB` will be set to the number of storage slots that were previously unset, and were set by this operation.
 
-### `SCWQ`: State clear sequential slots
+### `SCLR`: State clear sequential slots
 
 |             |                                                                                    |
 |-------------|------------------------------------------------------------------------------------|
 | Description | A sequential series of slots cleared from the current contract's state.            |
 | Operation   | ```STATE[MEM[$rA, 32], $rB] = None;```                                             |
-| Syntax      | `scwq $rA, $rC`                                                                    |
+| Syntax      | `sclr $rA, $rB`                                                                    |
 | Encoding    | `0x00 rA rB - -`                                                                   |
 | Notes       |                                                                                    |
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2395,16 +2395,16 @@ Panic if:
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Read storage slot contents to memory. Allows partial reads as well.                                    |
-| Operation   | `MEM[$rA, $rD] = STATE[MEM[$rC, 32]][$rB, $rD]`                                          |
+| Operation   | `MEM[$rA, $rD] = STATE[MEM[$rB, 32]][$rC, $rD]`                                                        |
 | Syntax      | `srdd $rA, $rB, $rC, $rD`                                                                              |
 | Encoding    | `0x00 rA rB rC rD`                                                                                     |
 | Effects     | Storage read                                                                                           |
-| Notes       | Gas is always charged for a full slot read. `$rB` is used to pass value in and out.                    |
+| Notes       | Gas is always charged for a full slot read.                                                            |
 Panic if:
 
-- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA + $rD` overflows or `> VM_MAX_RAM`
-- `$rB + $rD` overflows or `> len(STATE[MEM[$rC, 32]])`
+- `$rC + $rD` overflows or `> len(STATE[MEM[$rB, 32]])`
 - `$fp == 0` (in the script context)
 
 Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
@@ -2414,17 +2414,17 @@ Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise.
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Read storage slot contents to memory. Allows partial reads as well.                                    |
-| Operation   | `MEM[$rA, imm] = STATE[MEM[$rC, 32]][$rB, imm]; $rB = status`                                          |
+| Operation   | `MEM[$rA, imm] = STATE[MEM[$rB, 32]][$rC, imm]`                                                        |
 | Syntax      | `srdi $rA, $rB, $rC, imm`                                                                              |
 | Encoding    | `0x00 rA rB rC imm`                                                                                    |
 | Effects     | Storage read                                                                                           |
-| Notes       | Gas is always charged for a full slot read. `$rB` is used to pass value in and out.                    |
+| Notes       | Gas is always charged for a full slot read.                                                            |
 
 Panic if:
 
-- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA + imm` overflows or `> VM_MAX_RAM`
-- `$rB + imm` overflows or `> len(STATE[MEM[$rC, 32]])`
+- `$rC + imm` overflows or `> len(STATE[MEM[$rC, 32]])`
 - `$fp == 0` (in the script context)
 
 Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
@@ -2434,17 +2434,17 @@ Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise.
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Write storage slot from a memory buffer.                                                               |
-| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, $rD]`                                                                  |
-| Syntax      | `swrd $rA, $rB, $rC, $rD`                                                                              |
-| Encoding    | `0x00 rA rB rC $rD`                                                                                    |
+| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rB, $rC]`                                                                  |
+| Syntax      | `swrd $rA, $rB, $rC`                                                                                   |
+| Encoding    | `0x00 rA rB rC -`                                                                                      |
 | Effects     | Storage write                                                                                          |
 | Notes       |                                                                                                        |
 
 Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
-- `$rC + $rD` overflows or `> VM_MAX_RAM`
-- `$rD > MAX_STORAGE_SLOT_SIZE`
+- `$rB + $rC` overflows or `> VM_MAX_RAM`
+- `$rC > MAX_STORAGE_SLOT_SIZE`
 - `$fp == 0` (in the script context)
 
 ### `SWRI`: Write storage slot immediate
@@ -2452,16 +2452,16 @@ Panic if:
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Write storage slot from a memory buffer.                                                               |
-| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, imm]`                                                                  |
-| Syntax      | `swri $rA, $rB, $rC, imm`                                                                              |
-| Encoding    | `0x00 rA rB rC imm`                                                                                    |
+| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rB, imm]`                                                                  |
+| Syntax      | `swri $rA, $rB, imm`                                                                                   |
+| Encoding    | `0x00 rA rB i i`                                                                                       |
 | Effects     | Storage write                                                                                          |
 | Notes       |                                                                                                        |
 
 Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
-- `$rC + imm` overflows or `> VM_MAX_RAM`
+- `$rB + imm` overflows or `> VM_MAX_RAM`
 - `imm > MAX_STORAGE_SLOT_SIZE`
 - `$fp == 0` (in the script context)
 
@@ -2470,20 +2470,20 @@ Panic if:
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Read storage slot, modify or extend it, and write the modified value back.                             |
-| Operation   | `key=MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB==MAX?len(tmp):$rB, $rD] = MEM[$rC, $rD]; STATE[key] = tmp`|
+| Operation   | `key=MEM[$rA, 32]; tmp = STATE[key]; tmp[$rC==MAX?len(tmp):$rC, $rD] = MEM[$rB, $rD]; STATE[key] = tmp`|
 | Syntax      | `supd $rA, $rB, $rC, $rD`                                                                              |
 | Encoding    | `0x00 rA rB rC rD`                                                                                     |
 | Effects     | Storage read and write                                                                                 |
 | Notes       | Charges gas for full read and write. Writing past the end extends the slot, but offset must be valid.  |
 
-Passing in `u64::MAX` in `$rB` will cause the write to happen at the end of the slot, without needing to read the slot length first.
+Passing in `u64::MAX` in `$rC` will cause the write to happen at the end of the slot, without needing to read the slot length first.
 
 Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
-- `$rC + $rD` overflows or `> VM_MAX_RAM`
-- `$rB + $rD` overflows or `> MAX_STORAGE_SLOT_SIZE` (if `$rB == u64::MAX`, read `$rB` as `len(STATE[MEM[$rA, 32]])` instead)
-- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rB == u64::MAX`)
+- `$rB + $rD` overflows or `> VM_MAX_RAM`
+- `$rC + $rD` overflows or `> MAX_STORAGE_SLOT_SIZE` (if `$rC == u64::MAX`, read `$rC` as `len(STATE[MEM[$rA, 32]])` instead)
+- `$rC` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rC == u64::MAX`)
 - `$fp == 0` (in the script context)
 
 ### `SUPI`: Update storage slot (partial write) immediate
@@ -2491,7 +2491,7 @@ Panic if:
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Read storage slot, modify or extend it, and write the modified value back.                             |
-| Operation   | `key=MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB==MAX?len(tmp):$rB, imm] = MEM[$rC, imm]; STATE[key] = tmp`|
+| Operation   | `key=MEM[$rA, 32]; tmp = STATE[key]; tmp[$rC==MAX?len(tmp):$rC, imm] = MEM[$rB, imm]; STATE[key] = tmp`|
 | Syntax      | `supi $rA, $rB, $rC, imm`                                                                              |
 | Encoding    | `0x00 rA rB rC imm`                                                                                    |
 | Effects     | Storage read and write                                                                                 |
@@ -2502,9 +2502,9 @@ Passing in `u64::MAX` in `$rB` will cause the write to happen at the end of the 
 Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
-- `$rC + imm` overflows or `> VM_MAX_RAM`
-- `$rB + imm` overflows or `> MAX_STORAGE_SLOT_SIZE` (if `$rB == u64::MAX`, read `$rB` as `len(STATE[MEM[$rA, 32]])` instead)
-- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rB == u64::MAX`)
+- `$rB + imm` overflows or `> VM_MAX_RAM`
+- `$rC + imm` overflows or `> MAX_STORAGE_SLOT_SIZE` (if `$rC == u64::MAX`, read `$rC` as `len(STATE[MEM[$rA, 32]])` instead)
+- `$rC` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rC == u64::MAX`)
 - `$fp == 0` (in the script context)
 
 ### `SPLD`: Storage preload
@@ -2524,7 +2524,7 @@ Panic if:
 - `$rA` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-If the slot doesn't exist, sets `$rA = 0` and `$err = 1`. Otherwise `$rA` is set to the length of the slot, and `$err` to `0`.
+If the slot doesn't exist, sets `$rA = 0` and `$err = 1`, leaving the staging area unchanged. Otherwise `$rA` is set to the length of the slot, and `$err` to `0`.
 
 ### `SPCP`: Copy from preloaded storage slot
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2274,7 +2274,7 @@ This modifies the `balanceRoot` field of the appropriate output(s).
 
 ## Contract State Instructions
 
-### `SCWQ`: DEPRECATED State clear sequential slots
+### `SCWQ`: DEPRECATED State clear sequential 32 bytes slots
 
 |             |                                                                                    |
 |-------------|------------------------------------------------------------------------------------|

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -119,7 +119,7 @@
     - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
     - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
     - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
-    - [`SPLD`: Storage preload](#spld-storage-preload)
+    - [`SPLD`: State preload slot](#spld-state-preload-slot)
 - [Blob Instructions](#blob-instructions)
   - [`BSIZ`: Blob size](#bsiz-blob-size)
   - [`BLDD`: Load data from a blob](#bldd-load-data-from-a-blob)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2405,7 +2405,6 @@ Panic if:
 - `$rC + 32` overflows or `> VM_MAX_RAM`
 - `$rA + $rD` overflows or `> VM_MAX_RAM`
 - `$rB + $rD` overflows or `> len(STATE[MEM[$rC, 32]])`
-- `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
 Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
@@ -2426,7 +2425,6 @@ Panic if:
 - `$rC + 32` overflows or `> VM_MAX_RAM`
 - `$rA + imm` overflows or `> VM_MAX_RAM`
 - `$rB + imm` overflows or `> len(STATE[MEM[$rC, 32]])`
-- `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
 Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
@@ -2447,7 +2445,6 @@ Panic if:
 - `$rA + 32` overflows or `> VM_MAX_RAM`
 - `$rC + $rD` overflows or `> VM_MAX_RAM`
 - `$rD > MAX_STORAGE_SLOT_SIZE`
-- `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
 ### `SWRI`: Write storage slot immediate
@@ -2466,7 +2463,6 @@ Panic if:
 - `$rA + 32` overflows or `> VM_MAX_RAM`
 - `$rC + imm` overflows or `> VM_MAX_RAM`
 - `imm > MAX_STORAGE_SLOT_SIZE`
-- `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
 ### `SUPD`: Update storage slot (partial write)
@@ -2486,9 +2482,8 @@ Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
 - `$rC + $rD` overflows or `> VM_MAX_RAM`
-- `$rB + $rD` overflows or `> MAX_STORAGE_SLOT_SIZE`
-- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])`
-- `$rB` is a [reserved register](./index.md#semantics).
+- `$rB + $rD` overflows or `> MAX_STORAGE_SLOT_SIZE` (if `$rB == u64::MAX`, read `$rB` as `len(STATE[MEM[$rA, 32]])` instead)
+- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rB == u64::MAX`)
 - `$fp == 0` (in the script context)
 
 ### `SUPI`: Update storage slot (partial write) immediate
@@ -2508,9 +2503,8 @@ Panic if:
 
 - `$rA + 32` overflows or `> VM_MAX_RAM`
 - `$rC + imm` overflows or `> VM_MAX_RAM`
-- `$rB + imm` overflows or `> MAX_STORAGE_SLOT_SIZE`
-- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])`
-- `$rB` is a [reserved register](./index.md#semantics).
+- `$rB + imm` overflows or `> MAX_STORAGE_SLOT_SIZE` (if `$rB == u64::MAX`, read `$rB` as `len(STATE[MEM[$rA, 32]])` instead)
+- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rB == u64::MAX`)
 - `$fp == 0` (in the script context)
 
 ### `SPLD`: Storage preload

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -113,7 +113,7 @@
     - [`SWW`: State write word](#sww-state-write-word)
     - [`SWWQ`: DEPRECATED State write sequential 32 byte slots](#swwq-deprecated-state-write-sequential-32-byte-slots)
     - [`SCLR`: State clear sequential slots](#sclr-state-clear-sequential-slots)
-    - [`SRDD`: Read storage slot](#srdd-read-storage-slot)
+    - [`SRDD`: State read slot](#srdd-state-read-slot)
     - [`SRDI`: Read storage slot immediate](#srdi-read-storage-slot-immediate)
     - [`SWRD`: Write storage slot](#swrd-write-storage-slot)
     - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2389,7 +2389,7 @@ Panic if:
 - `$rA + 32` overflows or `> VM_MAX_RAM`
 - `$fp == 0` (in the script context)
 
-### `SRDD`: Read storage slot
+### `SRDD`: State read slot
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -116,7 +116,7 @@
     - [`SRDD`: State read slot](#srdd-state-read-slot)
     - [`SRDI`: State read slot immediate](#srdi-state-read-slot-immediate)
     - [`SWRD`: State write slot](#swrd-state-write-slot)
-    - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
+    - [`SWRI`: State write slot immediate](#swri-state-write-slot-immediate)
     - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
     - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
     - [`SPLD`: State preload slot](#spld-state-preload-slot)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -103,14 +103,22 @@
   - [`RETD`: Return from context with data](#retd-return-from-context-with-data)
   - [`RVRT`: Revert](#rvrt-revert)
   - [`SMO`: Send message to output](#smo-send-message-out)
-  - [`SCWQ`: State clear sequential 32 byte slots](#scwq-state-clear-sequential-32-byte-slots)
-  - [`SRW`: State read word](#srw-state-read-word)
-  - [`SRWQ`: State read sequential 32 byte slots](#srwq-state-read-sequential-32-byte-slots)
-  - [`SWW`: State write word](#sww-state-write-word)
-  - [`SWWQ`: State write sequential 32 byte slots](#swwq-state-write-sequential-32-byte-slots)
   - [`TIME`: Timestamp at height](#time-timestamp-at-height)
   - [`TR`: Transfer coins to contract](#tr-transfer-coins-to-contract)
   - [`TRO`: Transfer coins to output](#tro-transfer-coins-to-output)
+  - [Contract State Instructions](#contract-state-instructions)
+    - [`SCWQ`: State clear sequential slots](#scwq-state-clear-sequential-32-byte-slots)
+    - [`SRW`: State read word](#srw-state-read-word)
+    - [`SRWQ`: DEPRECATED State read sequential 32 byte slots](#srwq-deprecated-state-read-sequential-32-byte-slots)
+    - [`SWW`: State write word](#sww-state-write-word)
+    - [`SWWQ`: DEPRECATED State write sequential 32 byte slots](#swwq-deprecated-state-write-sequential-32-byte-slots)
+    - [`SRDD`: Read storage slot](#srdd-read-storage-slot)
+    - [`SRDI`: Read storage slot immediate](#srdi-read-storage-slot-immediate)
+    - [`SWRD`: Write storage slot](#swrd-write-storage-slot)
+    - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
+    - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-(partial-write))
+    - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-(partial-write)-immediate)
+    - [`SLEN`: Storage slot length](#slen-storage-slot-length)
 - [Blob Instructions](#blob-instructions)
   - [`BSIZ`: Blob size](#bsiz-blob-size)
   - [`BLDD`: Load data from a blob](#bldd-load-data-from-a-blob)
@@ -2164,104 +2172,6 @@ Append a receipt to the list of receipts:
 
 In an external context, decrease `MEM[balanceOfStart(0), 8]` by `$rD`. In an internal context, decrease asset ID 0 balance of output with contract ID `MEM[$fp, 32]` by `$rD`. This modifies the `balanceRoot` field of the appropriate contract that had its' funds deducted.
 
-### `SCWQ`: State clear sequential 32 byte slots
-
-|             |                                                                               |
-|-------------|-------------------------------------------------------------------------------|
-| Description | A sequential series of 32 bytes is cleared from the current contract's state. |
-| Operation   | ```STATE[MEM[$rA, 32], 32 * $rC] = None;```                                   |
-| Syntax      | `scwq $rA, $rB, $rC`                                                          |
-| Encoding    | `0x00 rA rB rC -`                                                             |
-| Notes       |                                                                               |
-
-Panic if:
-
-- `$rA + 32` overflows or `> VM_MAX_RAM`
-- `$rB` is a [reserved register](./index.md#semantics)
-- `$fp == 0` (in the script context)
-
-Register `$rB` will be set to `false` if any storage slot in the requested range was already unset (default) and `true` if all the slots were set.
-
-### `SRW`: State read word
-
-|             |                                                   |
-|-------------|---------------------------------------------------|
-| Description | A word is read from the current contract's state. |
-| Operation   | ```$rA = STATE[MEM[$rC, 32]][0, 8];```            |
-| Syntax      | `srw $rA, $rB, $rC`                               |
-| Encoding    | `0x00 rA rB rC -`                                 |
-| Effects     | Storage read                                      |
-| Notes       | Returns zero if the state element does not exist. |
-
-Panic if:
-
-- `$rA` is a [reserved register](./index.md#semantics)
-- `$rB` is a [reserved register](./index.md#semantics)
-- `$rC + 32` overflows or `> VM_MAX_RAM`
-- `$fp == 0` (in the script context)
-
-Register `$rB` will be set to `false` if the requested slot is unset (default) and `true` if it's set.
-
-### `SRWQ`: State read sequential 32 byte slots
-
-|             |                                                                            |
-|-------------|----------------------------------------------------------------------------|
-| Description | A sequential series of 32 bytes is read from the current contract's state. |
-| Operation   | ```MEM[$rA, 32 * rD] = STATE[MEM[$rC, 32], 32 * rD];```                    |
-| Syntax      | `srwq $rA, $rB, $rC, $rD`                                                  |
-| Encoding    | `0x00 rA rB rC rD`                                                         |
-| Effects     | Storage read                                                               |
-| Notes       | Returns zero if the state element does not exist.                          |
-
-Panic if:
-
-- `$rA + 32 * rD` overflows or `> VM_MAX_RAM`
-- `$rC + 32 * rD` overflows or `> VM_MAX_RAM`
-- `$rB` is a [reserved register](./index.md#semantics)
-- The memory range `MEM[$rA, 32 * rD]`  does not pass [ownership check](./index.md#ownership)
-- `$fp == 0` (in the script context)
-
-Register `$rB` will be set to `false` if any storage slot in the requested range is unset (default) and `true` if all the slots are set.
-
-### `SWW`: State write word
-
-|             |                                                                                 |
-|-------------|---------------------------------------------------------------------------------|
-| Description | A word is written to the current contract's state.                              |
-| Operation   | ```STATE[MEM[$rA, 32]][0, 8] = $rC;```<br>```STATE[MEM[$rA, 32]][8, 24] = 0;``` |
-| Syntax      | `sww $rA $rB $rC`                                                               |
-| Encoding    | `0x00 rA rB rC -`                                                               |
-| Effects     | Storage write                                                                   |
-| Notes       | Additional gas is charged when a new storage slot is created.                   |
-
-Panic if:
-
-- `$rA + 32` overflows or `> VM_MAX_RAM`
-- `$rB` is a [reserved register](./index.md#semantics)
-- `$fp == 0` (in the script context)
-
-The last 24 bytes of `STATE[MEM[$rA, 32]]` are set to `0`. Register `$rB` will be set to the number of new slots written, i.e. `1` if the slot was previously unset, and `0` if it already contained a value.
-
-### `SWWQ`: State write sequential 32 byte slots
-
-|             |                                                                             |
-|-------------|-----------------------------------------------------------------------------|
-| Description | A sequential series of 32 bytes is written to the current contract's state. |
-| Operation   | ```STATE[MEM[$rA, 32], 32 * $rD] = MEM[$rC, 32 * $rD];```                   |
-| Syntax      | `swwq $rA, $rB, $rC, $rD`                                                   |
-| Encoding    | `0x00 rA rB rC rD`                                                          |
-| Effects     | Storage write                                                               |
-| Notes       | Additional gas is charged when for each new storage slot created.           |
-
-Panic if:
-
-- `$rA + 32` overflows or `> VM_MAX_RAM`
-- `$rC + 32 * $rD` overflows or `> VM_MAX_RAM`
-- `$rB` is a [reserved register](./index.md#semantics)
-- `$fp == 0` (in the script context)
-
-Register `$rB` will be set to the number of storage slots that were previously unset, and were set by this operation.
-
 ### `TIME`: Timestamp at height
 
 |             |                                         |
@@ -2360,6 +2270,257 @@ In an external context, decrease `MEM[balanceOfStart(MEM[$rD, 32]), 8]` by `$rC`
 - `tx.outputs[$rB].asset_id = MEM[$rD, 32]`
 
 This modifies the `balanceRoot` field of the appropriate output(s).
+
+## Contract State Instructions
+
+### `SCWQ`: State clear sequential slots
+
+|             |                                                                               |
+|-------------|-------------------------------------------------------------------------------|
+| Description | A sequential series of slots cleared from the current contract's state.       |
+| Operation   | ```STATE[MEM[$rA, 32], $rC] = None;```                                        |
+| Syntax      | `scwq $rA, $rB, $rC`                                                          |
+| Encoding    | `0x00 rA rB rC -`                                                             |
+| Notes       |                                                                               |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$rB` is a [reserved register](./index.md#semantics)
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to `false` if any storage slot in the requested range was already unset (default) and `true` if all the slots were set.
+
+### `SRW`: State read word
+
+|             |                                                   |
+|-------------|---------------------------------------------------|
+| Description | A word is read from the current contract's state. |
+| Operation   | ```$rA = STATE[MEM[$rC, 32]][0, 8];```            |
+| Syntax      | `srw $rA, $rB, $rC`                               |
+| Encoding    | `0x00 rA rB rC -`                                 |
+| Effects     | Storage read                                      |
+| Notes       | Returns zero if the state element does not exist. |
+
+Panic if:
+
+- `$rA` is a [reserved register](./index.md#semantics)
+- `$rB` is a [reserved register](./index.md#semantics)
+- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$fp == 0` (in the script context)
+- `len(STATE[MEM[$rC, 32]]) < 8` (the storage slot doens't have enough data)
+
+Register `$rB` will be set to `false` if the requested slot is unset (default) and `true` if it's set.
+
+### `SRWQ`: DEPRECATED State read sequential 32 byte slots
+
+|             |                                                                                      |
+|-------------|--------------------------------------------------------------------------------------|
+| Description | A sequential series of 32 byte slots is read from the current contract's state.      |
+| Operation   | ```MEM[$rA, 32 * rD] = STATE[MEM[$rC, 32], rD];```                                   |
+| Syntax      | `srwq $rA, $rB, $rC, $rD`                                                            |
+| Encoding    | `0x00 rA rB rC rD`                                                                   |
+| Effects     | Storage read                                                                         |
+| Notes       | Legacy operation, unusable with variable-sized slots. Nonexistent slots read zeroes. |
+
+Panic if:
+
+- `$rA + 32 * rD` overflows or `> VM_MAX_RAM`
+- `$rC + 32 * rD` overflows or `> VM_MAX_RAM`
+- `$rB` is a [reserved register](./index.md#semantics)
+- The memory range `MEM[$rA, 32 * rD]`  does not pass [ownership check](./index.md#ownership)
+- `$fp == 0` (in the script context)
+- Any accessed storage slots has length other than 32 bytes.
+
+Register `$rB` will be set to `false` if any storage slot in the requested range is unset (default) and `true` if all the slots are set.
+
+### `SWW`: State write word
+
+|             |                                                                                                            |
+|-------------|------------------------------------------------------------------------------------------------------------|
+| Description | A word is written to the current contract's state.                                                         |
+| Operation   | ```STATE[MEM[$rA, 32]][0, 8] = $rC;```<br>```STATE[MEM[$rA, 32]][8, 24] = 0;```                            |
+| Syntax      | `sww $rA $rB $rC`                                                                                          |
+| Encoding    | `0x00 rA rB rC -`                                                                                          |
+| Effects     | Storage write                                                                                              |
+| Notes       | The resulting slot is zero-padded to 32 bytes. Additional gas is charged if a new storage slot is created. |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$rB` is a [reserved register](./index.md#semantics)
+- `$fp == 0` (in the script context)
+
+The last 24 bytes of `STATE[MEM[$rA, 32]]` are set to `0`. Register `$rB` will be set to the number of new slots written, i.e. `1` if the slot was previously unset, and `0` if it already contained a value.
+
+### `SWWQ`: DEPRECATED State write sequential 32 byte slots
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | A sequential series of 32 byte slots is written to the current contract's state.                       |
+| Operation   | ```STATE[MEM[$rA, 32], $rD] = MEM[$rC, 32 * $rD];```                                                   |
+| Syntax      | `swwq $rA, $rB, $rC, $rD`                                                                              |
+| Encoding    | `0x00 rA rB rC rD`                                                                                     |
+| Effects     | Storage write                                                                                          |
+| Notes       | Legacy operation, produces 32 byte slots. Additional gas is charged for each new storage slot created. |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$rC + 32 * $rD` overflows or `> VM_MAX_RAM`
+- `$rB` is a [reserved register](./index.md#semantics)
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to the number of storage slots that were previously unset, and were set by this operation.
+
+### `SRDD`: Read storage slot
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Read storage slot contents to memory. Allows partial reads as well.                                    |
+| Operation   | `MEM[$rA, $rD] = STATE[MEM[$rC, 32]][$rB, $rD]; $rB = status`                                          |
+| Syntax      | `srdd $rA, $rB, $rC, $rD`                                                                              |
+| Encoding    | `0x00 rA rB rC rD`                                                                                     |
+| Effects     | Storage read                                                                                           |
+| Notes       | Gas is always charged for a full slot read. `$rB` is used to pass value in and out.                    |
+Panic if:
+
+- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rA + $rD` overflows or `> VM_MAX_RAM`
+- `$rB + $rD` overflows or `> len(STATE[MEM[$rC, 32]])`
+- `$rB` is a [reserved register](./index.md#semantics).
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to `1` is the slot did exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
+
+
+### `SRDI`: Read storage slot immediate
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Read storage slot contents to memory. Allows partial reads as well.                                    |
+| Operation   | `MEM[$rA, imm] = STATE[MEM[$rC, 32]][$rB, imm]; $rB = status`                                          |
+| Syntax      | `srdi $rA, $rB, $rC, imm`                                                                              |
+| Encoding    | `0x00 rA rB rC imm`                                                                                    |
+| Effects     | Storage read                                                                                           |
+| Notes       | Gas is always charged for a full slot read. `$rB` is used to pass value in and out.                    |
+
+Panic if:
+
+- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rA + imm` overflows or `> VM_MAX_RAM`
+- `$rB + imm` overflows or `> len(STATE[MEM[$rC, 32]])`
+- `$rB` is a [reserved register](./index.md#semantics).
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to `1` is the slot did exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
+
+
+### `SWRD`: Write storage slot
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Write storage slot from a memory buffer.                                                               |
+| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, $rD]; $rB = status`                                                    |
+| Syntax      | `swrd $rA, $rB, $rC, $rD`                                                                              |
+| Encoding    | `0x00 rA rB rC $rD`                                                                                    |
+| Effects     | Storage write                                                                                          |
+| Notes       |                                                                                                        |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$rC + $rD` overflows or `> VM_MAX_RAM`
+- `$rD > MAX_STORAGE_SLOT_SIZE`
+- `$rB` is a [reserved register](./index.md#semantics).
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
+
+### `SWRI`: Write storage slot immediate
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Write storage slot from a memory buffer.                                                               |
+| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, imm]; $rB = status`                                                    |
+| Syntax      | `swri $rA, $rB, $rC, imm`                                                                              |
+| Encoding    | `0x00 rA rB rC imm`                                                                                    |
+| Effects     | Storage write                                                                                          |
+| Notes       |                                                                                                        |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$rC + imm` overflows or `> VM_MAX_RAM`
+- `imm > MAX_STORAGE_SLOT_SIZE`
+- `$rB` is a [reserved register](./index.md#semantics).
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
+
+### `SUPD`: Update storage slot (partial write)
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Read storage slot, modify it, and write the modified value back.                                       |
+| Operation   | `key = MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB, $rD] = MEM[$rC, $rD]; STATE[key] = tmp; $rB = status`  |
+| Syntax      | `supd $rA, $rB, $rC, $rD`                                                                              |
+| Encoding    | `0x00 rA rB rC rD`                                                                                     |
+| Effects     | Storage read and write                                                                                 |
+| Notes       | Charges gas for full read and write. Writing past the end extends the slot, but offset must be valid.  |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$rC + $rD` overflows or `> VM_MAX_RAM`
+- `$rB + $rD` overflows or `> MAX_STORAGE_SLOT_SIZE`
+- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])`
+- `$rB` is a [reserved register](./index.md#semantics).
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
+
+### `SUPI`: Update storage slot (partial write) immediate
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Read storage slot, modify it, and write the modified value back.                                       |
+| Operation   | `key = MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB, imm] = MEM[$rC, imm]; STATE[key] = tmp; $rB = status`  |
+| Syntax      | `supi $rA, $rB, $rC, imm`                                                                              |
+| Encoding    | `0x00 rA rB rC imm`                                                                                    |
+| Effects     | Storage read and write                                                                                 |
+| Notes       | Charges gas for full read and write. Writing past the end extends the slot, but offset must be valid.  |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$rC + imm` overflows or `> VM_MAX_RAM`
+- `$rB + imm` overflows or `> MAX_STORAGE_SLOT_SIZE`
+- `$rB` overflows or `> len(STATE[MEM[$rA, 32]])`
+- `$rB` is a [reserved register](./index.md#semantics).
+- `$fp == 0` (in the script context)
+
+Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
+
+### `SLEN`: Storage slot length
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Get the length of a storage slot.                                                                      |
+| Operation   | `$rA = len(STATE[MEM[$rC, 32]]); $rB = status`                                                         |
+| Syntax      | `slen $rA, $rB, $rC`                                                                                   |
+| Encoding    | `0x00 rA rB rC -`                                                                                      |
+| Effects     | Storage read                                                                                           |
+| Notes       | Charges gas for a full read.                                                                           |
+
+Panic if:
+
+- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rA` is a [reserved register](./index.md#semantics).
+- `$rB` is a [reserved register](./index.md#semantics).
+- `$fp == 0` (in the script context)
+
+If the slot doesn't exist, both `$rA` and `$rB` will be set to `0`. Otherwise `$rA` is set to the length of the slot, and `$rB` to `1`.
 
 ## Blob Instructions
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2527,24 +2527,6 @@ Panic if:
 
 If the slot doesn't exist, sets `$rA = 0` and `$err = 1`, leaving the staging area unchanged. Otherwise `$rA` is set to the length of the slot, and `$err` to `0`.
 
-### `SPCP`: Copy from preloaded storage slot
-
-|             |                                                                                                        |
-|-------------|--------------------------------------------------------------------------------------------------------|
-| Description | Copy memory from preloaded slot to main memory.                                                        |
-| Operation   | `MEM[$rA, $rC+imm] = STAGING[$rB, $rC+imm]                                                             |
-| Syntax      | `spcp $rA, $rB, $rC`                                                                                   |
-| Encoding    | `0x00 rA rB rC imm`                                                                                    |
-| Effects     | Storage read                                                                                           |
-| Notes       |                                                                                                        |
-
-Panic if:
-
-- `$rA + $rC + imm` overflows or `> VM_MAX_RAM`
-- The memory range `MEM[$rA, $rC + imm]` does not pass [ownership check](./index.md#ownership)
-- `$rB + $rC + imm` overflows or `> len(STAGING)`
-- `$fp == 0` (in the script context)
-
 ## Blob Instructions
 
 All these instructions advance the program counter `$pc` by `4` after performing their operation.

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2487,7 +2487,7 @@ Panic if:
 - `$rC` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rC == u64::MAX`)
 - `$fp == 0` (in the script context)
 
-### `SUPI`: Update storage slot (partial write) immediate
+### `SUPI`: State update slot (partial write) immediate
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2512,7 +2512,7 @@ Panic if:
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
-| Description | Preload a storage slot to a staging area, returning its length.                                        |
+| Description | Preload a storage slot to hot storage, returning its length.                                        |
 | Operation   | `STAGING = STATE[MEM[$rB, 32]]; $rA = len(STAGING)`                                                    |
 | Syntax      | `spld $rA, $rB`                                                                                        |
 | Encoding    | `0x00 rA rB - -`                                                                                       |

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -118,7 +118,7 @@
     - [`SWRD`: State write slot](#swrd-state-write-slot)
     - [`SWRI`: State write slot immediate](#swri-state-write-slot-immediate)
     - [`SUPD`: State update slot (partial write)](#supd-state-update-slot-partial-write)
-    - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
+    - [`SUPI`: State update slot (partial write) immediate](#supi-state-update-slot-partial-write-immediate)
     - [`SPLD`: State preload slot](#spld-state-preload-slot)
 - [Blob Instructions](#blob-instructions)
   - [`BSIZ`: Blob size](#bsiz-blob-size)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2409,7 +2409,7 @@ Panic if:
 
 Register `$err` will be set to `1` if the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
 
-### `SRDI`: Read storage slot immediate
+### `SRDI`: State read slot immediate
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -117,7 +117,7 @@
     - [`SRDI`: State read slot immediate](#srdi-state-read-slot-immediate)
     - [`SWRD`: State write slot](#swrd-state-write-slot)
     - [`SWRI`: State write slot immediate](#swri-state-write-slot-immediate)
-    - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
+    - [`SUPD`: State update slot (partial write)](#supd-state-update-slot-partial-write)
     - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
     - [`SPLD`: State preload slot](#spld-state-preload-slot)
 - [Blob Instructions](#blob-instructions)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -107,7 +107,7 @@
   - [`TR`: Transfer coins to contract](#tr-transfer-coins-to-contract)
   - [`TRO`: Transfer coins to output](#tro-transfer-coins-to-output)
   - [Contract State Instructions](#contract-state-instructions)
-    - [`SCWQ`: State clear sequential slots](#scwq-state-clear-sequential-32-byte-slots)
+    - [`SCWQ`: State clear sequential slots](#scwq-state-clear-sequential-slots)
     - [`SRW`: State read word](#srw-state-read-word)
     - [`SRWQ`: DEPRECATED State read sequential 32 byte slots](#srwq-deprecated-state-read-sequential-32-byte-slots)
     - [`SWW`: State write word](#sww-state-write-word)
@@ -116,8 +116,8 @@
     - [`SRDI`: Read storage slot immediate](#srdi-read-storage-slot-immediate)
     - [`SWRD`: Write storage slot](#swrd-write-storage-slot)
     - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
-    - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-(partial-write))
-    - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-(partial-write)-immediate)
+    - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
+    - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
     - [`SLEN`: Storage slot length](#slen-storage-slot-length)
 - [Blob Instructions](#blob-instructions)
   - [`BSIZ`: Blob size](#bsiz-blob-size)
@@ -2308,7 +2308,7 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics)
 - `$rC + 32` overflows or `> VM_MAX_RAM`
 - `$fp == 0` (in the script context)
-- `len(STATE[MEM[$rC, 32]]) < 8` (the storage slot doens't have enough data)
+- `len(STATE[MEM[$rC, 32]]) < 8` (the storage slot doesn't have enough data)
 
 Register `$rB` will be set to `false` if the requested slot is unset (default) and `true` if it's set.
 
@@ -2393,7 +2393,6 @@ Panic if:
 
 Register `$rB` will be set to `1` is the slot did exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
 
-
 ### `SRDI`: Read storage slot immediate
 
 |             |                                                                                                        |
@@ -2414,7 +2413,6 @@ Panic if:
 - `$fp == 0` (in the script context)
 
 Register `$rB` will be set to `1` is the slot did exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
-
 
 ### `SWRD`: Write storage slot
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -107,7 +107,7 @@
   - [`TR`: Transfer coins to contract](#tr-transfer-coins-to-contract)
   - [`TRO`: Transfer coins to output](#tro-transfer-coins-to-output)
   - [Contract State Instructions](#contract-state-instructions)
-    - [`SCWQ`: DEPRECATED State clear sequential slots](#scwq-deprecated-state-clear-sequential-slots)
+    - [`SCWQ`: DEPRECATED State clear sequential 32 bytes slots](#scwq-deprecated-state-clear-sequential-slots)
     - [`SRW`: State read word](#srw-state-read-word)
     - [`SRWQ`: DEPRECATED State read sequential 32 byte slots](#srwq-deprecated-state-read-sequential-32-byte-slots)
     - [`SWW`: State write word](#sww-state-write-word)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2525,7 +2525,7 @@ Panic if:
 - `$rA` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-If the slot doesn't exist, sets `$rA = 0` and `$err = 1`, leaving the staging area unchanged. Otherwise `$rA` is set to the length of the slot, and `$err` to `0`.
+If the slot doesn't exist, sets `$rA = 0` and `$err = 1`. Otherwise `$rA` is set to the length of the slot, and `$err` to `0`.
 
 ## Blob Instructions
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2508,7 +2508,7 @@ Panic if:
 - `$rC` overflows or `> len(STATE[MEM[$rA, 32]])` (except when `$rC == u64::MAX`)
 - `$fp == 0` (in the script context)
 
-### `SPLD`: Storage preload
+### `SPLD`: State preload slot
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -114,7 +114,7 @@
     - [`SWWQ`: DEPRECATED State write sequential 32 byte slots](#swwq-deprecated-state-write-sequential-32-byte-slots)
     - [`SCLR`: State clear sequential slots](#sclr-state-clear-sequential-slots)
     - [`SRDD`: State read slot](#srdd-state-read-slot)
-    - [`SRDI`: Read storage slot immediate](#srdi-read-storage-slot-immediate)
+    - [`SRDI`: State read slot immediate](#srdi-state-read-slot-immediate)
     - [`SWRD`: Write storage slot](#swrd-write-storage-slot)
     - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
     - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -107,18 +107,19 @@
   - [`TR`: Transfer coins to contract](#tr-transfer-coins-to-contract)
   - [`TRO`: Transfer coins to output](#tro-transfer-coins-to-output)
   - [Contract State Instructions](#contract-state-instructions)
-    - [`SCWQ`: State clear sequential slots](#scwq-state-clear-sequential-slots)
+    - [`SCWQ`: DEPRECATED State clear sequential slots](#scwq-deprecated-state-clear-sequential-slots)
     - [`SRW`: State read word](#srw-state-read-word)
     - [`SRWQ`: DEPRECATED State read sequential 32 byte slots](#srwq-deprecated-state-read-sequential-32-byte-slots)
     - [`SWW`: State write word](#sww-state-write-word)
     - [`SWWQ`: DEPRECATED State write sequential 32 byte slots](#swwq-deprecated-state-write-sequential-32-byte-slots)
+    - [`SCLR`: State clear sequential slots](#sclr-state-clear-sequential-slots)
     - [`SRDD`: Read storage slot](#srdd-read-storage-slot)
     - [`SRDI`: Read storage slot immediate](#srdi-read-storage-slot-immediate)
     - [`SWRD`: Write storage slot](#swrd-write-storage-slot)
     - [`SWRI`: Write storage slot immediate](#swri-write-storage-slot-immediate)
     - [`SUPD`: Update storage slot (partial write)](#supd-update-storage-slot-partial-write)
     - [`SUPI`: Update storage slot (partial write) immediate](#supi-update-storage-slot-partial-write-immediate)
-    - [`SLEN`: Storage slot length](#slen-storage-slot-length)
+    - [`SPRL`: Storage preload](#sprl-storage-preload)
 - [Blob Instructions](#blob-instructions)
   - [`BSIZ`: Blob size](#bsiz-blob-size)
   - [`BLDD`: Load data from a blob](#bldd-load-data-from-a-blob)
@@ -2273,15 +2274,15 @@ This modifies the `balanceRoot` field of the appropriate output(s).
 
 ## Contract State Instructions
 
-### `SCWQ`: State clear sequential slots
+### `SCWQ`: DEPRECATED State clear sequential slots
 
-|             |                                                                               |
-|-------------|-------------------------------------------------------------------------------|
-| Description | A sequential series of slots cleared from the current contract's state.       |
-| Operation   | ```STATE[MEM[$rA, 32], $rC] = None;```                                        |
-| Syntax      | `scwq $rA, $rB, $rC`                                                          |
-| Encoding    | `0x00 rA rB rC -`                                                             |
-| Notes       |                                                                               |
+|             |                                                                                    |
+|-------------|------------------------------------------------------------------------------------|
+| Description | A sequential series of slots cleared from the current contract's state.            |
+| Operation   | ```STATE[MEM[$rA, 32], $rC] = None;```                                             |
+| Syntax      | `scwq $rA, $rB, $rC`                                                               |
+| Encoding    | `0x00 rA rB rC -`                                                                  |
+| Notes       | Deprecated in favor of `SCLR`, which doesn't report status making it much cheaper. |
 
 Panic if:
 
@@ -2296,9 +2297,9 @@ Register `$rB` will be set to `false` if any storage slot in the requested range
 |             |                                                   |
 |-------------|---------------------------------------------------|
 | Description | A word is read from the current contract's state. |
-| Operation   | ```$rA = STATE[MEM[$rC, 32]][0, 8];```            |
-| Syntax      | `srw $rA, $rB, $rC`                               |
-| Encoding    | `0x00 rA rB rC -`                                 |
+| Operation   | ```$rA = STATE[MEM[$rC, 32]][imm * 8, 8];```      |
+| Syntax      | `srw $rA, $rB, $rC, imm`                          |
+| Encoding    | `0x00 rA rB rC imm`                               |
 | Effects     | Storage read                                      |
 | Notes       | Returns zero if the state element does not exist. |
 
@@ -2308,7 +2309,7 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics)
 - `$rC + 32` overflows or `> VM_MAX_RAM`
 - `$fp == 0` (in the script context)
-- `len(STATE[MEM[$rC, 32]]) < 8` (the storage slot doesn't have enough data)
+- `len(STATE[MEM[$rC, 32]]) < imm * 8 + 8` (the storage slot doesn't have enough data)
 
 Register `$rB` will be set to `false` if the requested slot is unset (default) and `true` if it's set.
 
@@ -2373,12 +2374,27 @@ Panic if:
 
 Register `$rB` will be set to the number of storage slots that were previously unset, and were set by this operation.
 
+### `SCWQ`: State clear sequential slots
+
+|             |                                                                                    |
+|-------------|------------------------------------------------------------------------------------|
+| Description | A sequential series of slots cleared from the current contract's state.            |
+| Operation   | ```STATE[MEM[$rA, 32], $rB] = None;```                                             |
+| Syntax      | `scwq $rA, $rC`                                                                    |
+| Encoding    | `0x00 rA rB - -`                                                                   |
+| Notes       |                                                                                    |
+
+Panic if:
+
+- `$rA + 32` overflows or `> VM_MAX_RAM`
+- `$fp == 0` (in the script context)
+
 ### `SRDD`: Read storage slot
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Read storage slot contents to memory. Allows partial reads as well.                                    |
-| Operation   | `MEM[$rA, $rD] = STATE[MEM[$rC, 32]][$rB, $rD]; $rB = status`                                          |
+| Operation   | `MEM[$rA, $rD] = STATE[MEM[$rC, 32]][$rB, $rD]`                                          |
 | Syntax      | `srdd $rA, $rB, $rC, $rD`                                                                              |
 | Encoding    | `0x00 rA rB rC rD`                                                                                     |
 | Effects     | Storage read                                                                                           |
@@ -2391,7 +2407,7 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-Register `$rB` will be set to `1` is the slot did exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
+Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
 
 ### `SRDI`: Read storage slot immediate
 
@@ -2412,14 +2428,14 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-Register `$rB` will be set to `1` is the slot did exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
+Register `$err` will be set to `1` is the slot did not exist, and `0` otherwise. If the slot didn't exist, memory is not modified.
 
 ### `SWRD`: Write storage slot
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Write storage slot from a memory buffer.                                                               |
-| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, $rD]; $rB = status`                                                    |
+| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, $rD]`                                                                  |
 | Syntax      | `swrd $rA, $rB, $rC, $rD`                                                                              |
 | Encoding    | `0x00 rA rB rC $rD`                                                                                    |
 | Effects     | Storage write                                                                                          |
@@ -2433,14 +2449,12 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
-
 ### `SWRI`: Write storage slot immediate
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
 | Description | Write storage slot from a memory buffer.                                                               |
-| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, imm]; $rB = status`                                                    |
+| Operation   | `STATE[MEM[$rA, 32]] = MEM[$rC, imm]`                                                                  |
 | Syntax      | `swri $rA, $rB, $rC, imm`                                                                              |
 | Encoding    | `0x00 rA rB rC imm`                                                                                    |
 | Effects     | Storage write                                                                                          |
@@ -2454,18 +2468,18 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
-
 ### `SUPD`: Update storage slot (partial write)
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
-| Description | Read storage slot, modify it, and write the modified value back.                                       |
-| Operation   | `key = MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB, $rD] = MEM[$rC, $rD]; STATE[key] = tmp; $rB = status`  |
+| Description | Read storage slot, modify or extend it, and write the modified value back.                             |
+| Operation   | `key=MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB==MAX?len(tmp):$rB, $rD] = MEM[$rC, $rD]; STATE[key] = tmp`|
 | Syntax      | `supd $rA, $rB, $rC, $rD`                                                                              |
 | Encoding    | `0x00 rA rB rC rD`                                                                                     |
 | Effects     | Storage read and write                                                                                 |
 | Notes       | Charges gas for full read and write. Writing past the end extends the slot, but offset must be valid.  |
+
+Passing in `u64::MAX` in `$rB` will cause the write to happen at the end of the slot, without needing to read the slot length first.
 
 Panic if:
 
@@ -2476,18 +2490,18 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
-
 ### `SUPI`: Update storage slot (partial write) immediate
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
-| Description | Read storage slot, modify it, and write the modified value back.                                       |
-| Operation   | `key = MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB, imm] = MEM[$rC, imm]; STATE[key] = tmp; $rB = status`  |
+| Description | Read storage slot, modify or extend it, and write the modified value back.                             |
+| Operation   | `key=MEM[$rA, 32]; tmp = STATE[key]; tmp[$rB==MAX?len(tmp):$rB, imm] = MEM[$rC, imm]; STATE[key] = tmp`|
 | Syntax      | `supi $rA, $rB, $rC, imm`                                                                              |
 | Encoding    | `0x00 rA rB rC imm`                                                                                    |
 | Effects     | Storage read and write                                                                                 |
 | Notes       | Charges gas for full read and write. Writing past the end extends the slot, but offset must be valid.  |
+
+Passing in `u64::MAX` in `$rB` will cause the write to happen at the end of the slot, without needing to read the slot length first.
 
 Panic if:
 
@@ -2498,27 +2512,41 @@ Panic if:
 - `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-Register `$rB` will be set to `1` is the slot didn't exist and was created, and `0` otherwise.
-
-### `SLEN`: Storage slot length
+### `SPLD`: Storage preload
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|
-| Description | Get the length of a storage slot.                                                                      |
-| Operation   | `$rA = len(STATE[MEM[$rC, 32]]); $rB = status`                                                         |
-| Syntax      | `slen $rA, $rB, $rC`                                                                                   |
-| Encoding    | `0x00 rA rB rC -`                                                                                      |
+| Description | Preload a storage slot to a staging area, returning its length.                                        |
+| Operation   | `STAGING = STATE[MEM[$rB, 32]]; $rA = len(STAGING)`                                                    |
+| Syntax      | `spld $rA, $rB`                                                                                        |
+| Encoding    | `0x00 rA rB - -`                                                                                       |
 | Effects     | Storage read                                                                                           |
 | Notes       | Charges gas for a full read.                                                                           |
 
 Panic if:
 
-- `$rC + 32` overflows or `> VM_MAX_RAM`
+- `$rB + 32` overflows or `> VM_MAX_RAM`
 - `$rA` is a [reserved register](./index.md#semantics).
-- `$rB` is a [reserved register](./index.md#semantics).
 - `$fp == 0` (in the script context)
 
-If the slot doesn't exist, both `$rA` and `$rB` will be set to `0`. Otherwise `$rA` is set to the length of the slot, and `$rB` to `1`.
+If the slot doesn't exist, sets `$rA = 0` and `$err = 1`. Otherwise `$rA` is set to the length of the slot, and `$err` to `0`.
+
+### `SPCP`: Copy from preloaded storage slot
+
+|             |                                                                                                        |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Description | Copy memory from preloaded slot to main memory.                                                        |
+| Operation   | `MEM[$rA, $rC+imm] = STAGING[$rB, $rC+imm]                                                             |
+| Syntax      | `spcp $rA, $rB, $rC`                                                                                   |
+| Encoding    | `0x00 rA rB rC imm`                                                                                    |
+| Effects     | Storage read                                                                                           |
+| Notes       |                                                                                                        |
+
+Panic if:
+
+- `$rA + $rC + imm` overflows or `> VM_MAX_RAM`
+- `$rB + $rC + imm` overflows or `> len(STAGING)`
+- `$fp == 0` (in the script context)
 
 ## Blob Instructions
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2476,7 +2476,7 @@ Panic if:
 | Effects     | Storage read and write                                                                                 |
 | Notes       | Charges gas for full read and write. Writing past the end extends the slot, but offset must be valid.  |
 
-Passing in `u64::MAX` in `$rC` will cause the write to happen at the end of the slot, without needing to read the slot length first.
+An unoccupied slot is treated as zero-length for the purposes of the read. Passing in `u64::MAX` in `$rC` will cause the write to happen at the end of the slot, without needing to read the slot length first.
 
 Panic if:
 
@@ -2497,7 +2497,7 @@ Panic if:
 | Effects     | Storage read and write                                                                                 |
 | Notes       | Charges gas for full read and write. Writing past the end extends the slot, but offset must be valid.  |
 
-Passing in `u64::MAX` in `$rB` will cause the write to happen at the end of the slot, without needing to read the slot length first.
+An unoccupied slot is treated as zero-length for the purposes of the read. Passing in `u64::MAX` in `$rC` will cause the write to happen at the end of the slot, without needing to read the slot length first.
 
 Panic if:
 

--- a/src/fuel-vm/instruction-set.md
+++ b/src/fuel-vm/instruction-set.md
@@ -2448,7 +2448,7 @@ Panic if:
 - `$rC > MAX_STORAGE_SLOT_SIZE`
 - `$fp == 0` (in the script context)
 
-### `SWRI`: Write storage slot immediate
+### `SWRI`: State write slot immediate
 
 |             |                                                                                                        |
 |-------------|--------------------------------------------------------------------------------------------------------|

--- a/src/tx-format/consensus_parameters.md
+++ b/src/tx-format/consensus_parameters.md
@@ -14,6 +14,7 @@
 | `MAX_SCRIPT_DATA_LENGTH`    | `uint64`  | Maximum length of script data, in bytes.                       |
 | `MAX_MESSAGE_DATA_LENGTH`   | `uint64`  | Maximum length of message data, in bytes.                      |
 | `MAX_STORAGE_SLOTS`         | `uint64`  | Maximum number of initial storage slots.                       |
+| `MAX_STORAGE_SLOT_LENGTH`   | `uint64`  | Maximum length of a storage slot data, in bytes.               |
 | `MAX_TRANSACTION_SIZE`      | `uint64`  | Maximum size of a transaction, in bytes.                       |
 | `MAX_WITNESSES`             | `uint64`  | Maximum number of witnesses.                                   |
 | `MAX_BYTECODE_SUBSECTIONS`  | `uint64`  | Maximum number of bytecode subsections.                        |


### PR DESCRIPTION
Discussed in #517. VM impl PR: https://github.com/FuelLabs/fuel-vm/pull/982

Adds a minimal set of opcodes required to operate with dynamic (variable-sized) storage slots. More instructions can be added later to speed up common operations, as discussed in #517.

This PR marks sequential bulk read and write opcodes as deprecated. There's no process for actually removing opcodes, but simply including DEPRECATED in the heading informs readers that they ought to be careful. Most imporatantly, the sequential read opcode now panics if attempting to read slots with size other than 32 bytes. The sequential clear instuction still works as expected and is kept as-is.

The PR also clarifies how the old storarge instructions interact with variable sized slots.

### Before requesting review
- [x] I have reviewed the code myself
